### PR TITLE
Restore lexicographical order of repositories

### DIFF
--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -48,6 +48,11 @@ BRANCH_PROTECTION_REQUIRED_STATUS_CHECK_MAP = {
     'creativecommons.github.io-source': [
         'continuous-integration/travis-ci'
     ],
+    'fonts': [
+        'ci/circleci: lint',
+        'ci/circleci: build',
+        'netlify/cc-fonts/deploy-preview'
+    ],
     'vocabulary': [
         'ci/circleci: lint',
         'ci/circleci: build',
@@ -58,11 +63,6 @@ BRANCH_PROTECTION_REQUIRED_STATUS_CHECK_MAP = {
         'ci/circleci: unit',
         'netlify/cc-vue-vocabulary/deploy-preview'
     ],
-    'fonts': [
-        'ci/circleci: lint',
-        'ci/circleci: build',
-        'netlify/cc-fonts/deploy-preview'
-    ]
 }
 
 


### PR DESCRIPTION
## Description
Moved the repository `creativecommons/fonts` higher up in the list to preserve the list's alphabetical order.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
