### PR TITLE
Add Workflow to update community PRs to Active Sprint – CC Search

### DIFF
--- a/.github/workflows/add_community_pr.yml
+++ b/.github/workflows/add_community_pr.yml
@@ -1,0 +1,30 @@
+name: Add Community PRs to Project
+on:
+  schedule:
+  # cron schedule expression to run at 5 minutes past every hour 
+    - cron: "5 * * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Handle cccatalog Repo
+      uses: subhamX/github-project-bot@v1.0.0
+      with:
+        ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+        COLUMN_NAME: "In Progress (Community)"
+        PROJECT_URL: https://github.com/orgs/creativecommons/projects/7
+        REPO_URL: https://github.com/creativecommons/cccatalog
+    - name: Handle cccatalog-api Repo
+      uses: subhamX/github-project-bot@v1.0.0
+      with:
+        ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+        COLUMN_NAME: "In Progress (Community)"
+        PROJECT_URL: https://github.com/orgs/creativecommons/projects/7
+        REPO_URL: https://github.com/creativecommons/cccatalog-api
+    - name: Handle cccatalog-frontend Repo
+      uses: subhamX/github-project-bot@v1.0.0
+      with:
+        ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+        COLUMN_NAME: "In Progress (Community)"
+        PROJECT_URL: https://github.com/orgs/creativecommons/projects/7
+        REPO_URL: https://github.com/creativecommons/cccatalog-frontend


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #23 

## Description
<!-- Add your description below. -->
Add workflow which is scheduled to run at 5 minutes past every hour.  It checks for PRs on the CC Search related repositories that don't have an associated project and adds them to project column `In Progress (Community)`

## Other information
Using the following GitHub Action [GitHub Project Bot](https://github.com/marketplace/actions/github-project-bot) to achieve the desired functionality.

CC Search related repos are:
* https://github.com/creativecommons/cccatalog
* https://github.com/creativecommons/cccatalog-api
* https://github.com/creativecommons/cccatalog-frontend

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
