### PR TITLE
Add manual push option if push fails - generate_projects_page.py

### DIFF
--- a/generate_projects_page/generate_projects_page.py
+++ b/generate_projects_page/generate_projects_page.py
@@ -159,7 +159,12 @@ def commit_and_push_changes(json_filename):
         repo.index.commit(message="Syncing new repository changes.")
         origin = repo.remotes.origin
         print("Pushing latest code...")
-        origin.push()
+        try:
+            origin.push()
+        except Exception as e:
+            print(f"Got exception {e} \n Trying manual push...")
+            g = git.Git(GIT_WORKING_DIRECTORY)
+            print(g.execute(["git", "push", f"{GITHUB_REPO_URL_WITH_CREDENTIALS}", "master"]))
     else:
         print("No changes to push...")
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #30 by @kgodey

## Description
The original code fails at the pushing step. So I decided to add a manual push command which would execute only when the current fails!

## Tests
The test that ran on my repo, with the manual push snippet only.
https://github.com/sp35/ccos-scripts/runs/558989418?check_suite_focus=true

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
