### PR TITLE
Revert and Correct "Replace circle ci tasks of vocabulary with the new github workflow's one"

### DIFF
--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -53,9 +53,9 @@ BRANCH_PROTECTION_REQUIRED_STATUS_CHECK_MAP = {
         "netlify/cc-fonts/deploy-preview",
     ],
     "vocabulary": [
-        "ci/circleci: lint",
-        "ci/circleci: test",
-        "ci/circleci: build",
+        "Lint",
+        "Unit tests",
+        "Build",
         "netlify/cc-vocabulary/deploy-preview",
     ],
     "vue-vocabulary": [

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -53,10 +53,10 @@ BRANCH_PROTECTION_REQUIRED_STATUS_CHECK_MAP = {
         "netlify/cc-fonts/deploy-preview",
     ],
     "vocabulary": [
-        "vocabulary-ci/Setup",
-        "vocabulary-ci/Lint",
-        "vocabulary-ci/Unit tests",
-        "vocabulary-ci/Build",
+        "ci/circleci: lint",
+        "ci/circleci: test",
+        "ci/circleci: build",
+        "netlify/cc-vocabulary/deploy-preview",
     ],
     "vue-vocabulary": [
         "ci/circleci: lint",


### PR DESCRIPTION
Reverts creativecommons/ccos-scripts#32
Fixes #26 