### PR TITLE
Groundwork for syncing CT Tracker to GH teams

### DIFF
--- a/push_data_to_ccos/get_community_team_data.py
+++ b/push_data_to_ccos/get_community_team_data.py
@@ -32,7 +32,8 @@ def generate_databag():
                 "members": [
                     {
                         "name": "",
-                        "role": ""
+                        "role": "",
+                        "github: ""
                     },
                     ...
                 ]
@@ -42,7 +43,8 @@ def generate_databag():
         "community_builders": [
             {
                 "name": "",
-                "role": ""
+                "role": "",
+                "github: ""
             },
             ...
         ]

--- a/push_data_to_ccos/get_community_team_data.py
+++ b/push_data_to_ccos/get_community_team_data.py
@@ -61,9 +61,10 @@ def generate_databag():
         if member["name"] == "":
             continue  # Sometimes blank names come up
         role = get_custom_field(member, "Role")
+        github = get_custom_field(member, "GitHub")
         if role.startswith("Community"):
             databag["community_builders"].append(
-                {"name": member["name"], "role": role}
+                {"name": member["name"], "role": role, "github": github}
             )
         else:
             project_name = get_custom_field(member, "Project Name")
@@ -82,7 +83,7 @@ def generate_databag():
             for project in databag["projects"]:
                 if project["name"] == project_name:
                     project["members"].append(
-                        {"name": member["name"], "role": role}
+                        {"name": member["name"], "role": role, "github": github}
                     )
                     break
 

--- a/push_data_to_ccos/get_community_team_data.py
+++ b/push_data_to_ccos/get_community_team_data.py
@@ -113,12 +113,11 @@ def get_custom_field(task, field_name):
     Gets the value of a custom field
     """
     for field in task["custom_fields"]:
-        if field["name"] == "Repo(s)" and field_name == "Repo(s)":
-            return field["text_value"]
-        elif field["name"] == field_name:
-            if field["enum_value"]:
+        if field["name"] == field_name:
+            if field["type"] == "enum":
                 return field["enum_value"]["name"]
-            return None
+            elif field["type"] == "text":
+                return field["text_value"]
 
 
 def get_community_team_data():


### PR DESCRIPTION
## Description
This PR lays the groundwork for automation of GitHub teams based on the Asana CT Tracker board. It adds GitHub handles to the CCOS databag that will then be used to populate the GitHub teams.

## Technical details
Also simplified the differentiation between text fields and enum fields, eliminating the need to hardcode field names.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
