### PR TITLE
Refinements to the CT to GH sync workflow

### DIFF
--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -165,7 +165,8 @@ def get_team_slug_name(project_name, role):
     @param role: the role held by folks in the team
     @return: the slug and name of the team
     """
-    team_name = f"CT: {project_name} {pluralized(role)}"
+    sanitized_role = pluralized(role).replace('Project ', '')
+    team_name = f"CT: {project_name} {sanitized_role}"
     team_slug = slugified(team_name)
     return team_slug, team_name
 

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -38,6 +38,7 @@ def create_teams_for_data(databag, client=None, organization=None):
         roles = project['roles']
         for role, members in roles.items():
             if role in ZERO_PERMISSION_ROLES:
+                print(f"    Skipping {role} as it has no privileges.")
                 continue
 
             members = [member['github'] for member in members]

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -8,6 +8,9 @@ GITHUB_ORGANIZATION = "creativecommons"
 GITHUB_TOKEN = os.environ["ADMIN_GITHUB_TOKEN"]
 
 
+ZERO_PERMISSION_ROLES = ['Project Contributor']
+
+
 def set_up_github_client():
     print("Setting up GitHub client...")
     github_client = Github(GITHUB_TOKEN)
@@ -34,6 +37,9 @@ def create_teams_for_data(databag, client=None, organization=None):
         repos = project['repos']
         roles = project['roles']
         for role, members in roles.items():
+            if role in ZERO_PERMISSION_ROLES:
+                continue
+
             members = [member['github'] for member in members]
             print("        Finding team...")
             team = map_role_to_team(organization, project_name, role)


### PR DESCRIPTION
## Fixes
Makes improvements to the workflow.

## Description
The PR make the following improvements:
- [x] Stops granting permissions to Project Contributors
- [x] Drops the word 'Project' from the role names
- [ ] Adds people who have privileges but have not been added to the organisation
- [ ] Sets up code review assignments (1 reviewer / round robin)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
