### PR TITLE
Add CODEOWNERS updates to the CT to GH sync workflow

### DIFF
--- a/sync_community_team/Pipfile
+++ b/sync_community_team/Pipfile
@@ -9,6 +9,7 @@ ipython = "*"
 [packages]
 pygithub = "*"
 requests = "*"
+gitpython = "*"
 
 [requires]
 python_version = "3.7"

--- a/sync_community_team/Pipfile.lock
+++ b/sync_community_team/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7c8ecf2f8e900c7006e9f9de0eb13b90ab279428e9360aa0a7edcb044cec1aba"
+            "sha256": "b4a9f1b8fe08a67131187f6c52b03ad8afe08a1c717c90cfc6a08c9f0124eee2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,6 +37,21 @@
             ],
             "version": "==1.2.10"
         },
+        "gitdb": {
+            "hashes": [
+                "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac",
+                "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"
+            ],
+            "version": "==4.0.5"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858",
+                "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"
+            ],
+            "index": "pypi",
+            "version": "==3.1.7"
+        },
         "idna": {
             "hashes": [
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
@@ -66,6 +81,13 @@
             ],
             "index": "pypi",
             "version": "==2.24.0"
+        },
+        "smmap": {
+            "hashes": [
+                "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4",
+                "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"
+            ],
+            "version": "==3.0.4"
         },
         "urllib3": {
             "hashes": [
@@ -150,10 +172,10 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:563d1a4140b63ff9dd587bda9557cffb2fe73650205ab6f4383092fb882e7dc8",
-                "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
+                "sha256:683397077a64cd1f750b71c05afcfc6612a7300cb6932666531e5a54f38ea564",
+                "sha256:7630ab85a23302839a0f26b31cc24f518e6155dea1ed395ea61b42c45941b6a6"
             ],
-            "version": "==3.0.5"
+            "version": "==3.0.6"
         },
         "ptyprocess": {
             "hashes": [

--- a/sync_community_team/get_community_team_data.py
+++ b/sync_community_team/get_community_team_data.py
@@ -68,7 +68,7 @@ def fetch_databag():
             role = member["role"]
             if role not in formatted_project["roles"]:
                 formatted_project["roles"][role] = []
-            del member['role']
+            del member["role"]
             formatted_project["roles"][role].append(member)
         databag["projects"].append(formatted_project)
 

--- a/sync_community_team/set_codeowners.py
+++ b/sync_community_team/set_codeowners.py
@@ -1,0 +1,305 @@
+import datetime
+import os
+import shutil
+from pathlib import Path
+
+# Third-party
+import git
+
+# Local
+from set_teams_on_github import map_role_to_team
+from utils import (
+    GITHUB_ORGANIZATION,
+    GITHUB_USERNAME,
+    GITHUB_TOKEN,
+    set_up_github_client,
+    get_cc_organization
+)
+
+
+GIT_USER_NAME = "CC creativecommons.github.io Bot"
+GIT_USER_EMAIL = "cc-creativecommons-github-io-bot@creativecommons.org"
+
+
+WORKING_DIRECTORY = Path("/tmp").resolve()
+
+
+SYNC_BRANCH = "ct_codeowners"
+
+
+def create_codeowners_for_data(databag):
+    set_up_git_user()
+
+    client = set_up_github_client()
+    organization = get_cc_organization(client)
+
+    print("Identifying and fixing CODEOWNER issues...")
+    projects = databag["projects"]
+    for project in projects:
+        project_name = project["name"]
+        print(f"    Identifying and fixing CODEOWNER issues for project {project_name}...")
+
+        print(f"        Finding all teams...")
+        roles = project["roles"]
+        teams = get_teams(organization, project_name, roles)
+        print(f"        Found {len(teams)} teams for project {project_name}.")
+
+        print(f"        Checking all projects...")
+        repos = project["repos"]
+        for repo in repos:
+            check_and_fix_repo(organization, repo, teams)
+    print("Done")
+
+
+def set_up_git_user():
+    """
+    Set the OS environment variables that pertain to Git configuration. These,
+    being set on the OS-level, do not need to be configured on a per-repo basis.
+    """
+    print("Setting up git user...")
+    os.environ["GIT_AUTHOR_NAME"] = GIT_USER_NAME
+    os.environ["GIT_AUTHOR_EMAIL"] = GIT_USER_EMAIL
+    os.environ["GIT_COMMITTER_NAME"] = GIT_USER_NAME
+    os.environ["GIT_COMMITTER_EMAIL"] = GIT_USER_EMAIL
+
+
+def get_teams(organization, project_name, roles):
+    """
+    Get all teams corresponding to the Community Team roles for the project.
+    Roles with no permissions do not form teams on GitHub and therefore will not
+    be represented in the resulting list.
+
+    @param organization: the organization whole teams are being fetched
+    @param project_name: the project whose teams are being fetching
+    @param roles: the filled roles in the project
+    @return: the list of GitHub teams for all Community Team roles
+    """
+    role_team_map = {
+        role: map_role_to_team(organization, project_name, role, False)
+        for role in roles.keys()
+    }
+    return [
+        team
+        for team in role_team_map.values()
+        if team is not None
+    ]
+
+
+def check_and_fix_repo(organization, repo, teams):
+    """
+    Identify issues with the CODEOWNERS file and rectify them. Missing
+    CODEOWNERS files will be created. Incomplete CODEOWNERS files will be
+    have new entries appended to them.
+
+    @param organization: the organization to which the repository belongs
+    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    """
+
+    print(f"            Checking and fixing {repo}...")
+    set_up_repo(repo)
+    fix_required = False
+
+    if not is_codeowners_present(repo):
+        fix_required = True
+        codeowners_path = get_codeowners_path(repo)
+        print("                CODEOWNERS does not exist, creating...")
+        os.makedirs(codeowners_path.parent, exist_ok=True)
+        open(codeowners_path, 'a').close()
+        print("                Done.")
+
+    team_mention_map = get_team_mention_map(repo, teams)
+    if not all(team_mention_map.values()):
+        fix_required = True
+        print("                CODEOWNERS is incomplete, populating...")
+        add_missing_teams(repo, team_mention_map)
+        print("                Done.")
+
+    if fix_required:
+        print("                Pushing to GitHub...")
+        branch_name = commit_and_push_changes(repo)
+        print(f"                Pushed to {branch_name}.")
+
+        print("                Opening a PR...")
+        pr = create_pull_request(organization, repo, branch_name)
+        print(f"                PR at {pr.url}.")
+
+    print("                Deleting clone...")
+    shutil.rmtree(get_repo_path(repo))
+    print("                Done.")
+
+    print("            All is well.")
+
+
+def commit_and_push_changes(repo):
+    """
+    Create a new branch and push the CODEOWNER to it. This branch will be named
+    in a particular format.
+
+    codeowner branch schema
+    ct_codeowners_<timestamp>
+
+    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @return: the name of the branch to which the changes were pushed
+    """
+    repo = git.Repo(get_repo_path(repo))
+
+    timestamp = int(datetime.datetime.now().timestamp())
+    branch_name = f"{SYNC_BRANCH}_{timestamp}"
+    repo.git.checkout("HEAD", b=branch_name)
+
+    repo.index.add(items=".github/CODEOWNERS")
+    repo.index.commit(message="Sync Community Team to CODEOWNERS")
+
+    origin = repo.remotes.origin
+    origin.push(f"{branch_name}:{branch_name}")
+
+    return branch_name
+
+
+def create_pull_request(organization, repo, branch_name):
+    """
+    Create a PR from the newly created branch to the base branch of the
+    repository containing the required changes to the CODEOWNERS.
+
+    @param organization: the organization to which the repository belongs
+    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param branch_name: the name of the branch containing the CODEOWNERS changes
+    """
+    repo = organization.get_repo(repo)
+    return repo.create_pull(
+        title="Sync Community Team to CODEOWNERS",
+        body="Hi! You might want to update your CODEOWNERS file.",
+        head=branch_name,
+        base=repo.default_branch  # could me 'main', 'master', 'prod' or something else
+    )
+
+
+def set_up_repo(repo):
+    """
+    Clone the repository and pull the main branch.
+
+    @param repo: the repository to set up
+    """
+    destination_path = get_repo_path(repo)
+    if not os.path.isdir(destination_path):
+        print("                Cloning repo...")
+        repo = git.Repo.clone_from(
+            url=get_github_repo_url_with_credentials(repo),
+            to_path=destination_path
+        )
+    else:
+        print("                Setting up repo...")
+        repo = git.Repo(destination_path)
+    origin = repo.remotes.origin
+    print("                Pulling latest code...")
+    origin.pull()
+
+
+def is_codeowners_present(repo):
+    """
+    Check whether the repository has a CODEOWNERS file.
+
+    @param repo: the repository in which to check the existence of CODEOWNERS
+    @return: True if a CODEOWNERS file exists, False otherwise
+    """
+    codeowners_path = get_codeowners_path(repo)
+    return codeowners_path.exists() and codeowners_path.is_file()
+
+
+def get_team_mention_map(repo, teams):
+    """
+    Map the team slugs to whether they have been mentioned in the CODEOWNERS
+    file in any capacity.
+
+    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param teams: all the GitHub teams for all Community Teams of a project
+    @return: a dictionary of team slugs and their mentions
+    """
+    codeowners_path = get_codeowners_path(repo)
+    with open(codeowners_path) as codeowners_file:
+        contents = codeowners_file.read()
+    return {
+        team.slug: mentionified(team.slug) in contents
+        for team in teams
+    }
+
+
+def add_missing_teams(repo, team_mention_map):
+    """
+    Add the mention forms for all missing teams in a new line.
+
+    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param team_mention_map: the dictionary of team slugs and their mentions
+    """
+    missing_team_slugs = [
+        team_slug
+        for team_slug in team_mention_map.keys()
+        if not team_mention_map[team_slug]
+    ]
+    codeowners_path = get_codeowners_path(repo)
+    with open(codeowners_path, "a") as codeowners_file:
+        addendum = generate_ideal_codeowners_rule(missing_team_slugs)
+        codeowners_file.write(addendum)
+        codeowners_file.write("\n")
+
+
+def generate_ideal_codeowners_rule(team_slugs):
+    """
+    Generate an ideal CODEOWNERS rule for the given set of roles. Assigns all
+    files using the wildcard expression '*' to the given roles.
+
+    @param team_slugs: the set of team slugs to be added to the CODEOWNERS file
+    @return: the line that should be added to the CODEOWNERS file
+    """
+    combined_team_slugs = " ".join(map(mentionified, team_slugs))
+    return f"* {combined_team_slugs}"
+
+
+def get_github_repo_url_with_credentials(repo):
+    """
+    Get the HTTPS URL to the repository which has the username and a GitHub
+    token for authentication.
+
+    @param repo: the name of the repository
+    @return: the authenticated URL to the repo
+    """
+    return (f"https://{GITHUB_USERNAME}:{GITHUB_TOKEN}"
+            f"@github.com/{GITHUB_ORGANIZATION}/{repo}.git")
+
+
+def get_repo_path(repo):
+    """
+    Get the fully qualified absolute path to the repository on the local file
+    system. Repositories are cloned into eponymous directories inside the
+    working directory.
+
+    @param repo: the name of the repository
+    @return: the absolute path to cloned repository on local FS
+    """
+    return WORKING_DIRECTORY.joinpath(repo)
+
+
+def get_codeowners_path(repo):
+    """
+    Get the fully qualified absolute path to the CODEOWNERS file inside the
+    given repository. By convention the file should be located inside the
+    '.github/' directory in the repository.
+
+    @param repo: the name of the repository
+    @return: the absolute path to the CODEOWNERS file
+    """
+    return get_repo_path(repo).joinpath(".github", "CODEOWNERS")
+
+
+def mentionified(team_slug):
+    """
+    Get the mention form of the given team. Mention forms are generated by
+    prefixing the organization to the team slug.
+
+    mention form schema
+    @<organization>/<team slug>
+
+    @param team_slug: the slug of the team to mention
+    @return: the mentionable form of the given team slug
+    """
+    return f"@{GITHUB_ORGANIZATION}/{team_slug}"

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -1,26 +1,15 @@
-import os
-import re
-
 # Third party
-from github import Github, UnknownObjectException
+from github import UnknownObjectException
 
-GITHUB_ORGANIZATION = "creativecommons"
-GITHUB_TOKEN = os.environ["ADMIN_GITHUB_TOKEN"]
+# Local
+from utils import (
+    set_up_github_client,
+    get_cc_organization,
+    get_team_slug_name
+)
 
 
 ZERO_PERMISSION_ROLES = ['Project Contributor']
-
-
-def set_up_github_client():
-    print("Setting up GitHub client...")
-    github_client = Github(GITHUB_TOKEN)
-    return github_client
-
-
-def get_cc_organization(github_client):
-    print("Getting CC's GitHub organization...")
-    cc = github_client.get_organization(GITHUB_ORGANIZATION)
-    return cc
 
 
 def create_teams_for_data(databag, client=None, organization=None):
@@ -149,57 +138,3 @@ def map_role_to_team(organization, project_name, role):
         )
         print("            Done.")
     return team
-
-
-def get_team_slug_name(project_name, role):
-    """
-    Get the team name and team slug based on GitHub's naming scheme. By
-    convention, teams are named in a well-defined .
-
-    team name schema
-    CT: <project name> <role, pluralized>
-
-    team slug schema
-    ct-<project_name_slug>-<role_slug>
-
-    @param project_name: the name of the project to which the team belongs
-    @param role: the role held by folks in the team
-    @return: the slug and name of the team
-    """
-    sanitized_role = pluralized(role).replace('Project ', '')
-    team_name = f"CT: {project_name} {sanitized_role}"
-    team_slug = slugified(team_name)
-    return team_slug, team_name
-
-
-def pluralized(word):
-    """
-    Get the plural of the given word. Contains a dictionary for non-standard
-    plural forms. If the word ends in one of 5 known endings, appends an 'es'
-    to the end. By default, just appends an 's' to the given word.
-
-    @param word: the word to pluralize
-    @return: the plural form of the noun
-    """
-    defined_plurals = {
-        "person": "people"
-    }
-    if word in defined_plurals:
-        return defined_plurals[word]
-
-    es_endings = ['s', 'sh', 'ch', 'x', 'z']
-    if any([word.endswith(ending) for ending in es_endings]):
-        return f"{word}es"
-    else:
-        return f"{word}s"
-
-
-def slugified(text):
-    """
-    Get the slug generated from the given text. Replaces all non-alphanumeric
-    characters with hyphens. Coalesces successive hyphens into one.
-
-    @param text: the text to slugify
-    @return: the slug made from the given text
-    """
-    return re.sub("-+", "-", re.sub(r"\W", "-", text.lower()))

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -12,11 +12,9 @@ from utils import (
 ZERO_PERMISSION_ROLES = ["Project Contributor"]
 
 
-def create_teams_for_data(databag, client=None, organization=None):
-    if client is None:
-        client = set_up_github_client()
-    if organization is None:
-        organization = get_cc_organization(client)
+def create_teams_for_data(databag):
+    client = set_up_github_client()
+    organization = get_cc_organization(client)
 
     print("Creating and populating teams...")
     projects = databag["projects"]

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -9,7 +9,7 @@ from utils import (
 )
 
 
-ZERO_PERMISSION_ROLES = ['Project Contributor']
+ZERO_PERMISSION_ROLES = ["Project Contributor"]
 
 
 def create_teams_for_data(databag, client=None, organization=None):
@@ -19,18 +19,18 @@ def create_teams_for_data(databag, client=None, organization=None):
         organization = get_cc_organization(client)
 
     print("Creating and populating teams...")
-    projects = databag['projects']
+    projects = databag["projects"]
     for project in projects:
-        project_name = project['name']
+        project_name = project["name"]
         print(f"    Creating and populating teams for project {project_name}...")
-        repos = project['repos']
-        roles = project['roles']
+        repos = project["repos"]
+        roles = project["roles"]
         for role, members in roles.items():
             if role in ZERO_PERMISSION_ROLES:
                 print(f"    Skipping {role} as it has no privileges.")
                 continue
 
-            members = [member['github'] for member in members]
+            members = [member["github"] for member in members]
             print("        Finding team...")
             team = map_role_to_team(organization, project_name, role)
             print("        Done.")
@@ -129,12 +129,12 @@ def map_role_to_team(organization, project_name, role):
         print("            Team exists, will update.")
     except UnknownObjectException:
         print("            Did not exist, creating...")
-        description = (f'Community Team for {project_name} '
+        description = (f"Community Team for {project_name} "
                        f'containing folks with the role "{role}"')
         team = organization.create_team(
             name=team_name,
             description=description,
-            privacy='closed'
+            privacy="closed"
         )
         print("            Done.")
     return team

--- a/sync_community_team/sync_teams.py
+++ b/sync_community_team/sync_teams.py
@@ -3,6 +3,8 @@
 # Local
 from get_community_team_data import get_community_team_data
 from set_teams_on_github import create_teams_for_data
+from set_codeowners import create_codeowners_for_data
 
 if __name__ == "__main__":
     create_teams_for_data(get_community_team_data())
+    create_codeowners_for_data(get_community_team_data())

--- a/sync_community_team/utils.py
+++ b/sync_community_team/utils.py
@@ -1,0 +1,75 @@
+import os
+import re
+
+# Third party
+from github import Github
+
+
+GITHUB_ORGANIZATION = "creativecommons"
+GITHUB_TOKEN = os.environ["ADMIN_GITHUB_TOKEN"]
+
+
+def set_up_github_client():
+    print("Setting up GitHub client...")
+    github_client = Github(GITHUB_TOKEN)
+    return github_client
+
+
+def get_cc_organization(github_client):
+    print("Getting CC's GitHub organization...")
+    cc = github_client.get_organization(GITHUB_ORGANIZATION)
+    return cc
+
+
+def get_team_slug_name(project_name, role):
+    """
+    Get the team name and team slug based on GitHub's naming scheme. By
+    convention, teams are named in a well-defined .
+
+    team name schema
+    CT: <project name> <role, pluralized>
+
+    team slug schema
+    ct-<project_name_slug>-<role_slug>
+
+    @param project_name: the name of the project to which the team belongs
+    @param role: the role held by folks in the team
+    @return: the slug and name of the team
+    """
+    sanitized_role = pluralized(role).replace('Project ', '')
+    team_name = f"CT: {project_name} {sanitized_role}"
+    team_slug = slugified(team_name)
+    return team_slug, team_name
+
+
+def pluralized(word):
+    """
+    Get the plural of the given word. Contains a dictionary for non-standard
+    plural forms. If the word ends in one of 5 known endings, appends an 'es'
+    to the end. By default, just appends an 's' to the given word.
+
+    @param word: the word to pluralize
+    @return: the plural form of the noun
+    """
+    defined_plurals = {
+        "person": "people"
+    }
+    if word in defined_plurals:
+        return defined_plurals[word]
+
+    es_endings = ['s', 'sh', 'ch', 'x', 'z']
+    if any([word.endswith(ending) for ending in es_endings]):
+        return f"{word}es"
+    else:
+        return f"{word}s"
+
+
+def slugified(text):
+    """
+    Get the slug generated from the given text. Replaces all non-alphanumeric
+    characters with hyphens. Coalesces successive hyphens into one.
+
+    @param text: the text to slugify
+    @return: the slug made from the given text
+    """
+    return re.sub("-+", "-", re.sub(r"\W", "-", text.lower()))

--- a/sync_community_team/utils.py
+++ b/sync_community_team/utils.py
@@ -6,6 +6,7 @@ from github import Github
 
 
 GITHUB_ORGANIZATION = "creativecommons"
+GITHUB_USERNAME = "cc-creativecommons-github-io-bot"
 GITHUB_TOKEN = os.environ["ADMIN_GITHUB_TOKEN"]
 
 

--- a/sync_community_team/utils.py
+++ b/sync_community_team/utils.py
@@ -36,7 +36,7 @@ def get_team_slug_name(project_name, role):
     @param role: the role held by folks in the team
     @return: the slug and name of the team
     """
-    sanitized_role = pluralized(role).replace('Project ', '')
+    sanitized_role = pluralized(role).replace("Project ", "")
     team_name = f"CT: {project_name} {sanitized_role}"
     team_slug = slugified(team_name)
     return team_slug, team_name
@@ -57,7 +57,7 @@ def pluralized(word):
     if word in defined_plurals:
         return defined_plurals[word]
 
-    es_endings = ['s', 'sh', 'ch', 'x', 'z']
+    es_endings = ["s", "sh", "ch", "x", "z"]
     if any([word.endswith(ending) for ending in es_endings]):
         return f"{word}es"
     else:


### PR DESCRIPTION
## Description
This PR adds the capability of identifying missing CODEOWNERS and opening PRs to address those inconsistencies.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
