### PR TITLE
Validate labels on all open issues

### DIFF
--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -49,8 +49,17 @@ def update_branch_protection(repo):
 
 if __name__ == "__main__":
     logger.log(logging.INFO, "Starting normalization")
+
+    logger.log(logging.INFO, "Loading labels...")
+    standard_labels, repo_specific_labels = get_labels()
+    logger.log(log.SUCCESS, "done.")
+
     logger.log(logging.INFO, "Syncing labels...")
-    set_labels(*get_labels())
+    set_labels(standard_labels, repo_specific_labels)
+    logger.log(log.SUCCESS, "done.")
+
+    logger.log(logging.INFO, "Validating labels...")
+    # TODO
     logger.log(log.SUCCESS, "done.")
 
     github = set_up_github_client()

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -16,6 +16,7 @@ import log
 from utils import get_cc_organization, set_up_github_client
 from get_labels import get_labels
 from set_labels import set_labels
+from validate_labels import validate_labels
 import branch_protections
 
 logger = logging.getLogger("normalize_repos")
@@ -59,7 +60,7 @@ if __name__ == "__main__":
     logger.log(log.SUCCESS, "done.")
 
     logger.log(logging.INFO, "Validating labels...")
-    # TODO
+    validate_labels(standard_labels, repo_specific_labels)
     logger.log(log.SUCCESS, "done.")
 
     github = set_up_github_client()

--- a/normalize_repos/validate_labels.py
+++ b/normalize_repos/validate_labels.py
@@ -1,0 +1,20 @@
+import json
+import logging
+import log
+
+logger = logging.getLogger("normalize_repos")
+log.reset_handler()
+
+
+def validate_labels(standard_labels, repo_specific_labels):
+    """
+    Validate all CC repos against the label specification. This checks that all
+    issues have exactly one mandatory label. This is the main entrypoint of the
+    module.
+    """
+
+    logger.log(logging.INFO, json.dumps(standard_labels))
+    logger.log(logging.INFO, json.dumps(repo_specific_labels))
+
+
+__all__ = [validate_labels]


### PR DESCRIPTION
## Fixes
This PR adds a validation module that validates labels on all open issues to make sure that they are in line with the labelling spec.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
