### PR TITLE
Added casefolding for label name comparisons.

### DIFF
--- a/normalize_repos/models.py
+++ b/normalize_repos/models.py
@@ -113,7 +113,7 @@ class Label:
 
         return all(
             [
-                self.qualified_name.casefold() == remote.name.casefold(),
+                self.qualified_name == remote.name,
                 self.color == remote.color,
                 self.description == remote.description,
             ]
@@ -129,7 +129,7 @@ class Label:
 
         return any(
             [
-                self.qualified_name.casefold() != remote.name.casefold(),
+                self.qualified_name != remote.name,
                 self.color != remote.color,
                 self.description != remote.description,
             ]

--- a/normalize_repos/models.py
+++ b/normalize_repos/models.py
@@ -113,7 +113,7 @@ class Label:
 
         return all(
             [
-                self.qualified_name == remote.name,
+                self.qualified_name.casefold() == remote.name.casefold(),
                 self.color == remote.color,
                 self.description == remote.description,
             ]
@@ -129,7 +129,7 @@ class Label:
 
         return any(
             [
-                self.qualified_name != remote.name,
+                self.qualified_name.casefold() != remote.name.casefold(),
                 self.color != remote.color,
                 self.description != remote.description,
             ]

--- a/normalize_repos/set_labels.py
+++ b/normalize_repos/set_labels.py
@@ -18,11 +18,11 @@ def map_repo_to_labels(repo, final_labels, non_destructive=True):
     """
 
     logger.log(logging.INFO, "Fetching initial labels...")
-    initial_labels = {label.name: label for label in repo.get_labels()}
+    initial_labels = {label.name.casefold(): label for label in repo.get_labels()}
     logger.log(log.SUCCESS, f"done. Found {len(initial_labels)} labels.")
 
     logger.log(logging.INFO, "Parsing final labels...")
-    final_labels = {label.qualified_name: label for label in final_labels}
+    final_labels = {label.qualified_name.casefold(): label for label in final_labels}
     logger.log(log.SUCCESS, f"done. Found {len(final_labels)} labels.")
 
     if not non_destructive:


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #84  by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
This PR is currently a work in progress to solve issue #84 
I added the `casefold()` method to allow for better syncing of the labels.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I basically have 2 options for how to solve this. The first involves adding casefolding to the `set_labels.py`. I am assuming the error was occurring for the conditional [on line 48](https://github.com/creativecommons/ccos-scripts/blob/master/normalize_repos/set_labels.py#L48-L50) in `set_labels.py`:
```python
if final_label_name not in initial_labels:
    logger.log(logging.INFO, "Did not exist, creating...")
    repo.create_label(**final_label.api_arguments)
```
`final_label_name` is a string and is checking its value against the key values of `initial_labels` which in this case are also strings. So if `final_label_name` have a value of `"Bug"` and lets say there is a key in `initial_labels` called `"bug"`, the conditional will succeed causing the label creation error. 

So my proposal for the change is to have the keys of both dictionaries housing the labels be normalized with a `casefold`.
```python
logger.log(logging.INFO, "Fetching initial labels...")
initial_labels = {label.name.casefold(): label for label in repo.get_labels()}
logger.log(log.SUCCESS, f"done. Found {len(initial_labels)} labels.")

logger.log(logging.INFO, "Parsing final labels...")
final_labels = {label.qualified_name.casefold(): label for label in final_labels}
logger.log(log.SUCCESS, f"done. Found {len(final_labels)} labels.")
``` 
I had reverted changes I initially made to have casefolidng in the equality operators in `models.py`. I did this as when comparing labels, we want to make sure that there is differences found when we want to intentionally update the casing of a label. 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
I wasn't able to test this with your code as I don't have access to your repository. However, I set up a private repository to test the functions myself. Based on the changes I made, I was able to effectively sync the labels while taking the case insensitivity of GitHub.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- I added tests for the changes I made (if applicable). N/A 
- I added or updated documentation (if applicable). N/A
- I tried running the project locally and verified that there are no
  visible errors. N/A

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
