### PR TITLE
Add args, improve exception handling, reorganize imports

### DIFF
--- a/normalize_repos/Pipfile
+++ b/normalize_repos/Pipfile
@@ -14,4 +14,4 @@ pygithub = "*"
 pyyaml = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3"

--- a/normalize_repos/Pipfile.lock
+++ b/normalize_repos/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c7bd4110cb55cf6001c8da42a9b9edaa2331544118886b48f6d817aca236c804"
+            "sha256": "40b208a963cd6a2cf3794e879b2f3d73f714a670c62da39d765a67ab9c4ccb10"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -88,11 +88,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "wrapt": {
             "hashes": [
@@ -140,29 +140,35 @@
         },
         "regex": {
             "hashes": [
-                "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204",
-                "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162",
-                "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f",
-                "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb",
-                "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6",
-                "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7",
-                "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88",
-                "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99",
-                "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644",
-                "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a",
-                "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840",
-                "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067",
-                "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd",
-                "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4",
-                "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e",
-                "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89",
-                "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e",
-                "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc",
-                "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf",
-                "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341",
-                "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"
+                "sha256:02686a2f0b1a4be0facdd0d3ad4dc6c23acaa0f38fb5470d892ae88584ba705c",
+                "sha256:137da580d1e6302484be3ef41d72cf5c3ad22a076070051b7449c0e13ab2c482",
+                "sha256:20cdd7e1736f4f61a5161aa30d05ac108ab8efc3133df5eb70fe1e6a23ea1ca6",
+                "sha256:25991861c6fef1e5fd0a01283cf5658c5e7f7aa644128e85243bc75304e91530",
+                "sha256:26b85672275d8c7a9d4ff93dbc4954f5146efdb2ecec89ad1de49439984dea14",
+                "sha256:2f60ba5c33f00ce9be29a140e6f812e39880df8ba9cb92ad333f0016dbc30306",
+                "sha256:3dd952f3f8dc01b72c0cf05b3631e05c50ac65ddd2afdf26551638e97502107b",
+                "sha256:578ac6379e65eb8e6a85299b306c966c852712c834dc7eef0ba78d07a828f67b",
+                "sha256:5d4a3221f37520bb337b64a0632716e61b26c8ae6aaffceeeb7ad69c009c404b",
+                "sha256:608d6c05452c0e6cc49d4d7407b4767963f19c4d2230fa70b7201732eedc84f2",
+                "sha256:65b6b018b07e9b3b6a05c2c3bb7710ed66132b4df41926c243887c4f1ff303d5",
+                "sha256:698f8a5a2815e1663d9895830a063098ae2f8f2655ae4fdc5dfa2b1f52b90087",
+                "sha256:6c72adb85adecd4522a488a751e465842cdd2a5606b65464b9168bf029a54272",
+                "sha256:6d4cdb6c20e752426b2e569128488c5046fb1b16b1beadaceea9815c36da0847",
+                "sha256:6e9f72e0ee49f7d7be395bfa29e9533f0507a882e1e6bf302c0a204c65b742bf",
+                "sha256:828618f3c3439c5e6ef8621e7c885ca561bbaaba90ddbb6a7dfd9e1ec8341103",
+                "sha256:85b733a1ef2b2e7001aff0e204a842f50ad699c061856a214e48cfb16ace7d0c",
+                "sha256:8958befc139ac4e3f16d44ec386c490ea2121ed8322f4956f83dd9cad8e9b922",
+                "sha256:a51e51eecdac39a50ede4aeed86dbef4776e3b73347d31d6ad0bc9648ba36049",
+                "sha256:aeac7c9397480450016bc4a840eefbfa8ca68afc1e90648aa6efbfe699e5d3bb",
+                "sha256:aef23aed9d4017cc74d37f703d57ce254efb4c8a6a01905f40f539220348abf9",
+                "sha256:af1f5e997dd1ee71fb6eb4a0fb6921bf7a778f4b62f1f7ef0d7445ecce9155d6",
+                "sha256:b5eeaf4b5ef38fab225429478caf71f44d4a0b44d39a1aa4d4422cda23a9821b",
+                "sha256:d25f5cca0f3af6d425c9496953445bf5b288bb5b71afc2b8308ad194b714c159",
+                "sha256:d81be22d5d462b96a2aa5c512f741255ba182995efb0114e5a946fe254148df1",
+                "sha256:e935a166a5f4c02afe3f7e4ce92ce5a786f75c6caa0c4ce09c922541d74b77e8",
+                "sha256:ef3a55b16c6450574734db92e0a3aca283290889934a23f7498eaf417e3af9f0"
             ],
-            "version": "==2020.7.14"
+            "version": "==2020.10.15"
         },
         "toml": {
             "hashes": [

--- a/normalize_repos/README.md
+++ b/normalize_repos/README.md
@@ -12,11 +12,11 @@ new labels. It will never delete labels.
 ## Running the Script
 
 1. Install [Pipenv](https://pipenv.readthedocs.io/en/latest/)
-2. Navigate to the `normalize_repos` folder and run `pipenv install`
+2. Navigate to the `normalize_repos` folder and run `pipenv install --dev`
 3. Set the `ADMIN_GITHUB_TOKEN` environment variable with your GitHub token.
    You will need a GitHub token with admin permissions to the `creativecommons`
    GitHub organization.
-4. Run the script: `python3 normalize_repos.py`
+4. Run the script: `pipenv run normalize_repos.py`
 
 
 ## Repository README

--- a/normalize_repos/get_labels.py
+++ b/normalize_repos/get_labels.py
@@ -1,6 +1,8 @@
-import json
+# Standard library
 from pathlib import Path
+import json
 
+# Local/library specific
 from models import Group, Label
 
 

--- a/normalize_repos/log.py
+++ b/normalize_repos/log.py
@@ -1,5 +1,7 @@
+# Standard library
 import inspect
 import logging
+
 
 SUCCESS = logging.INFO + 1
 

--- a/normalize_repos/models.py
+++ b/normalize_repos/models.py
@@ -1,3 +1,4 @@
+# Local/library specific
 from utils import COLORS
 
 

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -72,7 +72,8 @@ def get_select_repos(args):
         if not repos:
             raise ScriptError(
                 "Specified repositories do not include any valid"
-                f" repositories: {args.repos}")
+                f" repositories: {args.repos}"
+            )
     repos.sort(key=lambda repo: repo.name)
     return repos
 

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -49,6 +49,7 @@ def setup():
         action="append",
         help="repository or repositories to update (instead of fetching"
         " repositories from GitHub)",
+        metavar="REPO",
         dest="repos",
     )
     args = ap.parse_args()

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -47,8 +47,8 @@ def setup():
         "--repo",
         "--repository",
         action="append",
-        help="repository or repositories to update (instead of fetching"
-        " repositories from GitHub)",
+        help="select repository or repositories to update from those fetched"
+        " from GitHub (may be specified multiple times)",
         metavar="REPO",
         dest="repos",
     )

--- a/normalize_repos/normalize_repos.py
+++ b/normalize_repos/normalize_repos.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # vim: set fileencoding=utf-8:
+
 """
 This script ensures that all active repositories in the creativecommons GitHub
 organization are consistent. Please see README.md.
@@ -8,20 +9,19 @@ organization are consistent. Please see README.md.
 # Standard library
 import logging
 
-# noinspection PyUnresolvedReferences
-import set_up_logging
+# Third-party
+from github import UnknownObjectException
+import yaml  # For converting .cc-metadata.yml to Python dictionary
 
 # Local/library specific
-import log
-from utils import get_cc_organization, set_up_github_client
 from get_labels import get_labels
 from set_labels import set_labels
+from utils import get_cc_organization, set_up_github_client
 import branch_protections
+import log
 
-# For converting .cc-metadata.yml to Python dictionary
-import yaml
-from github import UnknownObjectException
 
+log.set_up_logging()
 logger = logging.getLogger("normalize_repos")
 log.reset_handler()
 
@@ -73,6 +73,7 @@ if __name__ == "__main__":
 
     github = set_up_github_client()
     repos = get_cc_repos(github)
+
     for repo in repos:
         # TODO: Set up automatic deletion of merged branches
         update_branch_protection(repo)

--- a/normalize_repos/set_labels.py
+++ b/normalize_repos/set_labels.py
@@ -2,7 +2,6 @@
 import logging
 
 # Local/library specific
-from utils import set_up_github_client, get_cc_organization
 import log
 
 
@@ -69,22 +68,13 @@ def map_repo_to_labels(repo, final_labels, non_destructive=True):
     logger.log(log.SUCCESS, "done.")
 
 
-def set_labels(standard_labels, repo_specific_labels):
+def set_labels(repos, standard_labels, repo_specific_labels):
     """
     Set labels on all repos for the organisation. This is the main entrypoint of
     the module.
     """
 
-    logger.log(logging.INFO, "Setting up...")
-    client = set_up_github_client()
-    organization = get_cc_organization(client)
-    logger.log(log.SUCCESS, "done.")
-
-    logger.log(logging.INFO, "Fetching repos...")
-    repos = list(organization.get_repos())
-    logger.log(log.SUCCESS, f"done. Found {len(repos)} repos.")
-
-    for repo in repos:
+    for repo in list(repos):
         logger.log(logging.INFO, f"Getting labels for repo '{repo.name}'...")
         labels = standard_labels + repo_specific_labels.get(repo.name, [])
         logger.log(log.SUCCESS, f"done. Found {len(labels)} labels.")

--- a/normalize_repos/set_labels.py
+++ b/normalize_repos/set_labels.py
@@ -1,7 +1,10 @@
+# Standard library
 import logging
+
+# Local/library specific
+from utils import set_up_github_client, get_cc_organization
 import log
 
-from utils import set_up_github_client, get_cc_organization
 
 logger = logging.getLogger("normalize_repos")
 log.reset_handler()

--- a/normalize_repos/set_labels.py
+++ b/normalize_repos/set_labels.py
@@ -18,11 +18,15 @@ def map_repo_to_labels(repo, final_labels, non_destructive=True):
     """
 
     logger.log(logging.INFO, "Fetching initial labels...")
-    initial_labels = {label.name.casefold(): label for label in repo.get_labels()}
+    initial_labels = {
+        label.name.casefold(): label for label in repo.get_labels()
+    }
     logger.log(log.SUCCESS, f"done. Found {len(initial_labels)} labels.")
 
     logger.log(logging.INFO, "Parsing final labels...")
-    final_labels = {label.qualified_name.casefold(): label for label in final_labels}
+    final_labels = {
+        label.qualified_name.casefold(): label for label in final_labels
+    }
     logger.log(log.SUCCESS, f"done. Found {len(final_labels)} labels.")
 
     if not non_destructive:

--- a/normalize_repos/set_up_logging.py
+++ b/normalize_repos/set_up_logging.py
@@ -1,3 +1,0 @@
-from log import set_up_logging
-
-set_up_logging()

--- a/normalize_repos/utils.py
+++ b/normalize_repos/utils.py
@@ -1,11 +1,13 @@
+# Standard library
 import os
 import logging
 
 # Third party
 from github import Github
 
-# Local
+# Local/library specific
 import log
+
 
 logger = logging.getLogger("normalize_repos")
 log.reset_handler()


### PR DESCRIPTION
## Description
- Refactored to only fetch repositories once (instead of twice)
- Added argument handling:
    ```
    usage: normalize_repos.py [-h] [-r REPO] [--skip-branches] [--skip-labels]
    
    This script ensures that all active repositories in the creativecommons GitHub
    organization are consistent. Please see README.md.
    
    optional arguments:
      -h, --help            show this help message and exit
      -r REPO, --repo REPO, --repository REPO
                            select repository or repositories to update from those
                            fetched from GitHub (may be specified multiple times)
      --skip-branches       skip branches update
      --skip-labels         skip labels update

    ```
  - (added options make testing *much easier*)
- Improved error and exception handling
- Reorganized main to allow easier debugging
- Organized imports
- Reformatted with black

## Tests
Tested locally (script still fails due repositories not containing a `master` branch--see #95)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
