### PR TITLE
Changes to labels.json to remove hacktoberfest labels

### DIFF
--- a/normalize_repos/README.md
+++ b/normalize_repos/README.md
@@ -2,7 +2,7 @@
 
 This script ensures that all active repositories in the creativecommons GitHub
 organization are consistent in the following ways:
-* They have all the labels defined in `labels.py` present.
+* They have all the labels defined in `labels.json` present.
 * They have standard branch protections set up (with some exceptions).
 
 This script will only update color and description of existing labels or create

--- a/normalize_repos/labels.json
+++ b/normalize_repos/labels.json
@@ -158,20 +158,6 @@
       "color": "000000",
       "description": "Aaargh!",
       "emoji": "\uD83E\uDD2F"
-    },
-    {
-      "name": "Hacktoberfest",
-      "color": "883255",
-      "description": "Ideal for Hacktoberfest participation",
-      "emoji": "\uD83C\uDF83",
-      "has_emoji_name":  false
-    },
-    {
-      "name": "invalid",
-      "color": "LIGHTER",
-      "description": "Spam PRs for Hacktoberfest",
-      "emoji": "⛔️",
-      "has_emoji_name":  false
     }
   ]
 }


### PR DESCRIPTION
## Fixes
Fixes #97 by @nimishbongale

## Description
Removes the relevant JSON objects associated with the 2 hacktoberfest labels.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
