### PR TITLE
Run the track new issues in backlog workflow hourly and switch to a new implementation

### DIFF
--- a/.github/workflows/track_backlog.yml
+++ b/.github/workflows/track_backlog.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Track all issues
-      uses: dhruvkb/issue-projector@0.0.6
+      uses: dhruvkb/issue-projector@0.0.7
       with:
         ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         ORG_NAME: 'creativecommons'
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Track all PRs
-      uses: dhruvkb/issue-projector@0.0.6
+      uses: dhruvkb/issue-projector@0.0.7
       with:
         ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         ORG_NAME: 'creativecommons'

--- a/.github/workflows/track_backlog.yml
+++ b/.github/workflows/track_backlog.yml
@@ -4,7 +4,8 @@ on:
   schedule:
   - cron: "45 * * * *" # Run at 45 minutes past the hour, every hour
 jobs:
-  build:
+  add_issues_to_project:
+    name: Track all issues
     runs-on: ubuntu-latest
     steps:
     - name: Track all issues
@@ -18,6 +19,10 @@ jobs:
         ISSUE_TYPE: 'issue'
         INTERVAL: 1
         INTERVAL_UNIT: 'h'
+  add_prs_to_project:
+    name: Track all PRs
+    runs-on: ubuntu-latest
+    steps:
     - name: Track all PRs
       uses: dhruvkb/issue-projector@0.0.6
       with:

--- a/.github/workflows/track_backlog.yml
+++ b/.github/workflows/track_backlog.yml
@@ -2,13 +2,13 @@ name: Track new issues in backlog
 on:
   workflow_dispatch:
   schedule:
-  - cron: "45 0 * * *" # Run at 45 minutes past midnight
+  - cron: "45 * * * *" # Run at 45 minutes past the hour, every hour
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Track all issues
-      uses: dhruvkb/issue-projector@0.0.5
+      uses: dhruvkb/issue-projector@0.0.6
       with:
         ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         ORG_NAME: 'creativecommons'
@@ -16,11 +16,15 @@ jobs:
         COLUMN_NAME: 'Pending Review'
         EXCLUDED_PROJECT_NUMBER: 7 # Active sprint
         ISSUE_TYPE: 'issue'
+        INTERVAL: 1
+        INTERVAL_UNIT: 'h'
     - name: Track all PRs
-      uses: dhruvkb/issue-projector@0.0.5
+      uses: dhruvkb/issue-projector@0.0.6
       with:
         ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         ORG_NAME: 'creativecommons'
         PROJECT_NUMBER: 7 # Active sprint
         COLUMN_NAME: 'Code Review'
         ISSUE_TYPE: 'pr'
+        INTERVAL: 1
+        INTERVAL_UNIT: 'h'


### PR DESCRIPTION
## Description
Run the workflow hourly. Also ups the action version to 0.0.6β which fixes the API abuse problems.

## Technical details
The new implementation adds the issue to the project first, and uses the response to determine if the issue was already in that particular project. This eliminates the need to pull in every single card from the project when adding the new cards.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors. _Not locally per se, but in [`purelyfortesting`](https://github.com/purelyfortesting)._

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
