### PR TITLE
Incomplete issue labelling

### DIFF
--- a/normalize_repos/labels.yml
+++ b/normalize_repos/labels.yml
@@ -34,6 +34,10 @@ groups:
         color: 'DARK'
         description: Needs more details before it can be worked on
         emoji: "🧹"
+      - name: label work required
+        color: 'DARK'
+        description: Needs proper labelling before it can be worked on
+        emoji: "🏷"
       - name: discarded
         color: 'LIGHTER'
         description: Will not be worked on

--- a/normalize_repos/validate_issues.py
+++ b/normalize_repos/validate_issues.py
@@ -9,6 +9,7 @@ logger = logging.getLogger("normalize_repos")
 log.reset_handler()
 
 TRIAGE_LABEL = "🚦 status: awaiting triage"
+LABEL_WORK_REQUIRED_LABEL = "🏷 status: label work required"
 
 
 def dump_invalid_issues(invalid_issues):
@@ -55,8 +56,12 @@ def are_issue_labels_valid(issue, required_groups):
         if not label_names.intersection(required_labels):
             missing_groups.append(group.name)
     if missing_groups:
+        issue.add_to_labels(LABEL_WORK_REQUIRED_LABEL)
         logger.log(logging.INFO, f"Issue '{issue.title}' has missing labels.")
         return False, f"Missing labels from groups: {', '.join(missing_groups)}"
+    else:
+        if LABEL_WORK_REQUIRED_LABEL in label_names:
+            issue.remove_from_labels(LABEL_WORK_REQUIRED_LABEL)
 
     logger.log(logging.INFO, f"Issue '{issue.title}' is OK.")
     return True, None


### PR DESCRIPTION
## Description
This PR defines a new label `🏷 status: label work required` and applies it to the issues that need work on the labels. It also removes the label from issues that had their labels fixed.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
