### PR TITLE
Fix TypeError in __all__

### DIFF
--- a/normalize_repos/log.py
+++ b/normalize_repos/log.py
@@ -162,4 +162,4 @@ def change_indent(delta=1):
             formatter.delta_indent(delta)
 
 
-__all__ = [set_up_logging, reset_handler, change_indent, SUCCESS]
+__all__ = ["set_up_logging", "reset_handler", "change_indent", "SUCCESS"]

--- a/normalize_repos/set_labels.py
+++ b/normalize_repos/set_labels.py
@@ -83,4 +83,4 @@ def set_labels(repos, standard_labels, repo_specific_labels):
         logger.log(log.SUCCESS, "done.")
 
 
-__all__ = [set_labels]
+__all__ = ["set_labels"]

--- a/normalize_repos/validate_issues.py
+++ b/normalize_repos/validate_issues.py
@@ -130,4 +130,4 @@ def validate_issues(repos, groups):
     dump_invalid_issues(invalid_issues)
 
 
-__all__ = [validate_issues]
+__all__ = ["validate_issues"]


### PR DESCRIPTION
## Fixes
Fixes #105  by @dhruvkb 

## Description
Passed variable names to the `__all__` list instead of variables directly in python modules as instructed in the issue description

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
