### PR TITLE
Fix the split command to accept commas without the following space 

### DIFF
--- a/sync_community_team/get_community_team_data.py
+++ b/sync_community_team/get_community_team_data.py
@@ -7,6 +7,8 @@ This file intentionally has an external API identical to that of
 `push_data_to_ccos/get_community_team_data.py`.
 """
 
+import re
+
 # Third party
 import requests
 
@@ -60,7 +62,7 @@ def fetch_databag():
     for project in projects:
         formatted_project = {
             "name": project["name"],
-            "repos": project["repos"].split(", "),
+            "repos": re.split(r",\s?", project["repos"]),
             "roles": {}
         }
         members = project["members"]

--- a/sync_community_team/set_codeowners.py
+++ b/sync_community_team/set_codeowners.py
@@ -45,7 +45,7 @@ def create_codeowners_for_data(databag):
         print(f"        Found {len(teams)} teams for project {project_name}.")
 
         print(f"        Checking all projects...")
-        repos = project["repos"][0].split(',')
+        repos = project["repos"]
         for repo in repos:
             check_and_fix_repo(organization, repo, teams)
     print("Done")

--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -37,7 +37,7 @@ def create_teams_for_data(databag):
             print("        Done.")
 
             print(f"        Populating repos for team {team.name}...")
-            repos = project["repos"][0].split(',')
+            repos = project["repos"]
             map_team_to_repos(organization, team, repos, True)
             set_team_repo_permissions(team, PERMISSIONS[role])
             print("        Done.")


### PR DESCRIPTION
## Description
The repos were not being split as written in the code because of missing spaces.

## Technical details
The function that fetches the databag from CC Open Source expects the repos field to be a comma separated string of the format `<item_one>, <item two>`. It was being given `<item one>,<item two>`. Hard to spot the difference?

```diff
- <item_one>, <item two>
+ <item one>,<item two>
```

Making the `_` optional in `,_` makes the split logic work correctly, removing the need for patches. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
