### PR TITLE
Update Log Format for GitHub Workflow Commands

### DIFF
--- a/normalize_repos/log.py
+++ b/normalize_repos/log.py
@@ -13,6 +13,14 @@ class IndentFormatter(logging.Formatter):
     indentation using ``'\t'`` characters.
     """
 
+    color_map = {
+        logging.CRITICAL: 31,  # red
+        logging.ERROR: 31,  # red
+        logging.WARNING: 33,  # yellow
+        SUCCESS: 32,  # green
+        logging.INFO: 34,  # blue
+    }
+
     @staticmethod
     def identify_cut(filenames):
         """
@@ -51,11 +59,26 @@ class IndentFormatter(logging.Formatter):
         """
 
         prefix = "\u001b["
+        color = f"{self.color_map[record.levelno]}m"
         bold = "1m"
         reset = "0m"
-        self._style._fmt = (
-            "::%(levelname)-8s file=%(filename)-20s,line=%(lineno)-4d::"
-            "%(asctime)s │ "
+        if record.levelname in ["WARNING", "ERROR"]:
+            self._style._fmt = (
+                "::%(levelname)s file=%(filename)s,line=%(lineno)d::"
+                "%(asctime)s │ "
+            )
+        elif record.levelname == "DEBUG":
+            self._style._fmt = (
+                "::%(levelname)s::"
+                "%(asctime)s │ "
+            )
+        else:
+            self._style._fmt = (
+                "%(asctime)s │ "
+                f"{prefix}{color}%(levelname)-8s{prefix}{reset} │ "
+            )
+
+        self._style._fmt += (
             f"%(indent)s{prefix}{bold}%(function)s{prefix}{reset}: "
             "%(message)s"
         )

--- a/normalize_repos/log.py
+++ b/normalize_repos/log.py
@@ -13,14 +13,6 @@ class IndentFormatter(logging.Formatter):
     indentation using ``'\t'`` characters.
     """
 
-    color_map = {
-        logging.CRITICAL: 31,  # red
-        logging.ERROR: 31,  # red
-        logging.WARNING: 33,  # yellow
-        SUCCESS: 32,  # green
-        logging.INFO: 34,  # blue
-    }
-
     @staticmethod
     def identify_cut(filenames):
         """
@@ -59,12 +51,10 @@ class IndentFormatter(logging.Formatter):
         """
 
         prefix = "\u001b["
-        color = f"{self.color_map[record.levelno]}m"
         bold = "1m"
         reset = "0m"
         self._style._fmt = (
-            "%(asctime)s │ "
-            f"{prefix}{color}%(levelname)-8s{prefix}{reset} │ "
+            "::%(levelname)-8s:: %(asctime)s │ "
             f"%(indent)s{prefix}{bold}%(function)s{prefix}{reset}: "
             "%(message)s"
         )

--- a/normalize_repos/log.py
+++ b/normalize_repos/log.py
@@ -54,7 +54,8 @@ class IndentFormatter(logging.Formatter):
         bold = "1m"
         reset = "0m"
         self._style._fmt = (
-            "::%(levelname)-8s:: %(asctime)s │ "
+            "::%(levelname)-8s file=%(filename)-20s,line=%(lineno)-4d::"
+            "%(asctime)s │ "
             f"%(indent)s{prefix}{bold}%(function)s{prefix}{reset}: "
             "%(message)s"
         )


### PR DESCRIPTION
## Fixes
Fixes #112 by @dhruvkb 

## Description
This PR changes the log format to match the format for GitHub workflow commands. The ASCII color-coding was dropped. The following is the format for logs as proposed in this PR:
`::levelname:: time | indent function(bold) | messages`

## Screenshots
The following is the screenshot of the `Normalize Repos` workflow result on the manual trigger in my fork. Now the formatted logs is being identified with their workflow command.

![Screenshot from 2020-12-17 15-41-44](https://user-images.githubusercontent.com/54344426/102474355-8b2d7080-407e-11eb-8c96-2083bd5452ed.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
