### PR TITLE
Default branch is now main

### DIFF
--- a/.github/workflows/normalize_repos.yml
+++ b/.github/workflows/normalize_repos.yml
@@ -5,7 +5,7 @@ on:
   - cron: '0 0 * * *'
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push_data_to_ccos.yml
+++ b/.github/workflows/push_data_to_ccos.yml
@@ -4,7 +4,7 @@ on:
   - cron: '15 0 * * *'
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_community_team.yml
+++ b/.github/workflows/sync_community_team.yml
@@ -4,7 +4,7 @@ on:
   - cron: '30 0 * * *'
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ information about that script.
 | Workflow Name/Status | YML File Name | Workflow Purpose |
 | -------------------- | ------------- | ---------------- |
 | [![Add Community PRs to Project][b1]][l1] | [`add_community_pr.yml`][community_pr_yml] | Runs hourly at 5 minutes past every hour UTC and adds new Vocabulary issues to [Vocabulary: In Progress][vocab_in_progress] |
-| [![Normalize Repos][b2]][l2] | [`normalize_repos.yml`][norm_pr_yml] | Runs daily at 00:00 UTC and whenever someone pushes to master branch and uses [`normalize_repos`][norm] |
-| [![Push data to CC Open Source][b3]][l3] | [`push_data_to_ccos.yml`][push_ccos_yml] | Runs daily at 00:00 UTC and whenever someone pushes to master branch and uses [`push_data_to_ccos`][push_to_ccos] |
-| [![Sync Community Teams with GitHub][b4]][l4] | [`sync_community_team.yml`][sync_team_yml] | Runs daily at 00:30 UTC and whenever someone pushes to master branch and uses [`sync_community_team`][sync_team] |
+| [![Normalize Repos][b2]][l2] | [`normalize_repos.yml`][norm_pr_yml] | Runs daily at 00:00 UTC and whenever someone pushes to main branch and uses [`normalize_repos`][norm] |
+| [![Push data to CC Open Source][b3]][l3] | [`push_data_to_ccos.yml`][push_ccos_yml] | Runs daily at 00:00 UTC and whenever someone pushes to main branch and uses [`push_data_to_ccos`][push_to_ccos] |
+| [![Sync Community Teams with GitHub][b4]][l4] | [`sync_community_team.yml`][sync_team_yml] | Runs daily at 00:30 UTC and whenever someone pushes to main branch and uses [`sync_community_team`][sync_team] |
 | [![Track new issues in backlog][b5]][l5] | [`track_backlog.yml`][track_backlog] | Runs hourly at 45 minutes past every hour UTC and adds community PRs to [Active Sprint: Code Review][active_sprint] and new issues to [Backlog: Pending Review][backlog_pending] |
 
 

--- a/normalize_repos/branch_protections.py
+++ b/normalize_repos/branch_protections.py
@@ -13,9 +13,9 @@ EXEMPT_REPOSITORIES = [
     "cc.i18n",
     # exempted to allow community maintainer to self-merge PRs
     "ccsearch-browser-extension",
-    # exempted for bot pushes to master
+    # exempted for bot pushes to default branch
     "creativecommons.github.io-source",
-    # exempted for bot pushes to master
+    # exempted for bot pushes to default branch
     "creativecommons.github.io",
     # non-engineering repo
     "global-network-strategy",


### PR DESCRIPTION
## Description
Update repo now that the default branch is now `main`

## Context
[[Meta] Support "main" as a default branch name · Issue #1125 · creativecommons/creativecommons.org](https://github.com/creativecommons/creativecommons.org/issues/1125)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
