### PR TITLE
fail gracefully when a user does not exist (ex. GitHub user rename)

### DIFF
--- a/sync_community_team/set_teams_on_github.py
+++ b/sync_community_team/set_teams_on_github.py
@@ -12,7 +12,7 @@ PERMISSIONS = {
 }
 
 
-def create_teams_for_data(databag):
+def create_teams_for_data(databag, exit_status):
     client = set_up_github_client()
     organization = get_cc_organization(client)
 
@@ -41,14 +41,15 @@ def create_teams_for_data(databag):
 
             print(f"        Populating members for team {team.name}...")
             members = [member["github"] for member in members]
-            map_team_to_members(client, team, members, True)
+            exit_status = map_team_to_members(client, team, members, exit_status, True)
             print("        Done.")
         print("    Done.")
     print("Done.")
+    return exit_status
 
 
 def map_team_to_members(
-    client, team, final_user_logins, non_destructive=False
+    client, team, final_user_logins, exit_status, non_destructive=False
 ):
     """
     Map the team to the given set of members. Any members that are not already
@@ -78,13 +79,15 @@ def map_team_to_members(
                 user = client.get_user(login)
             except UnknownObjectException:
                 print(f"            ERROR: User not found: {login}")
-                raise
+                exit_status = 1
+                continue
             team.add_membership(user)
 
     current_login = client.get_user().login
     if current_login not in final_user_logins:
         current_user = client.get_user(current_login)
         team.remove_membership(current_user)
+    return exit_status
 
 
 def map_team_to_repos(

--- a/sync_community_team/sync_teams.py
+++ b/sync_community_team/sync_teams.py
@@ -18,8 +18,10 @@ class ScriptError(Exception):
 
 
 def main():
-    create_teams_for_data(get_community_team_data())
+    exit_status = 0
+    exit_status = create_teams_for_data(get_community_team_data(), exit_status)
     create_codeowners_for_data(get_community_team_data())
+    sys.exit(exit_status)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
fail gracefully when a user does not exist (ex. GitHub user rename):
- update to continue when a user does not exist, but also exit (at the end) with an error so the underlying issue is not hidden

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
