### PR TITLE
add keepalive-workflow

### DIFF
--- a/.github/workflows/normalize_repos.yml
+++ b/.github/workflows/normalize_repos.yml
@@ -30,3 +30,8 @@ jobs:
       with:
         name: invalid-issue-report
         path: /tmp/invalid_issues.yml
+    - uses: gautamkrishnar/keepalive-workflow@1.07
+      with:
+        committer_username: cc-open-source-bot
+        committer_email: opensource@creativecommons.org
+        time_elapsed: 46

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Planning][vocab_plan] project.
 | **Env** | | |
 | | Required: | `ADMIN_GITHUB_TOKEN` |
 
-This worflow creates GitHub teams for the Community teams and updates their membership based on the [`community_team_members.json`][databag] Lektor databag.
+This creates GitHub teams for the Community teams and updates their membership
+based on the [`community_team_members.json`][databag] Lektor databag.
  - The databag is used to create the [Community Team Members — Creative
    Commons Open Source][ctlistpage] page
  - The databag is kept up-to-date by [Push data to CC Open
@@ -104,7 +105,8 @@ This worflow creates GitHub teams for the Community teams and updates their memb
 | **Env** | | |
 | | Required: | `ADMIN_GITHUB_TOKEN` |
 
-This workflow adds PRs to [Active Sprint: Code Review][active_sprint] and new issues to [Backlog: Pending Review][backlog_pending].
+This adds PRs to [Active Sprint: Code Review][active_sprint] and new issues to
+[Backlog: Pending Review][backlog_pending].
 
 [track_backlog]: .github/workflows/track_backlog.yml
 [issue_bot]: https://github.com/dhruvkb/issue-projector
@@ -122,19 +124,22 @@ This workflow adds PRs to [Active Sprint: Code Review][active_sprint] and new is
 | | File: | [`normalize_repos.py`][norm_file] |
 | | Common Modules: | [`ccos/`](ccos/) |
 | | Specific Modules: | [`ccos/norm/`](ccos/norm/) |
+| **Action** | | |
+| | | [gautamkrishnar/keepalive-workflow][keepalive] |
 | **Env** | | |
 | | Required: | `ADMIN_GITHUB_TOKEN` |
 
-This workflow ensures that all active repositories in the creativecommons
+This ensures that all active repositories in the creativecommons
 GitHub organization are consistent in the following ways:
 - They have all the labels defined in `labels.yml` present.
 - They have standard branch protections set up (with some exceptions).
 
-This script will only update color and description of existing labels or create
+This will only update color and description of existing labels or create
 new labels. It will never delete labels.
 
 [norm_pr_yml]: .github/workflows/normalize_repos.yml
 [norm_file]: normalize_repos.py
+[keepalive]: https://github.com/gautamkrishnar/keepalive-workflow
 
 
 ### Push data to CC Open Source
@@ -151,8 +156,8 @@ new labels. It will never delete labels.
 | | Required: | `ADMIN_ASANA_TOKEN` |
 | | Required: | `ADMIN_GITHUB_TOKEN` |
 
-This workflow retreives data from Asana, formats it as a lektor databag, and
-pushes it to CC Open Source website source repository:
+This retreives data from Asana, formats it as a lektor databag, and pushes it
+to CC Open Source website source repository:
 - Data Source: [Community Team Tracking - Asana][asana] (limited access)
 - Data Destination:
   - [`creativecommons/creativecommons.github.io-source`][ccos_source]


### PR DESCRIPTION
## Description
add [gautamkrishnar/keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow):
> GitHub action to prevent GitHub from suspending your cronjob based triggers due to repository inactivity

## Technical details
[Disabling and enabling workflows - Usage limits, billing, and administration - GitHub Docs](https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows):
> In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
