### PR TITLE
Separate system and app python configuration (fix order of operations)

### DIFF
--- a/.github/workflows/normalize_repos.yml
+++ b/.github/workflows/normalize_repos.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
     - name: Install app dependencies
-        run: |
+      run: |
         pipenv sync
     - name: Run script with token in env
       run: |

--- a/.github/workflows/normalize_repos.yml
+++ b/.github/workflows/normalize_repos.yml
@@ -10,19 +10,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Install system dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pipenv
+    - uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+    - name: Install app dependencies
+        run: |
         pipenv sync
-    - name: Export token to env and run normalize script
+    - name: Run script with token in env
       run: |
         pipenv run ./normalize_repos.py
       env:

--- a/.github/workflows/push_data_to_ccos.yml
+++ b/.github/workflows/push_data_to_ccos.yml
@@ -9,17 +9,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Install system dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pipenv
+    - uses: actions/checkout@v3
+    - name: Install app dependencies
+      run: |
         pipenv sync
-    - name: Export token to env and run script
+    - name: Run script with tokens in env
       run: |
         pipenv run ./push_data_to_ccos.py
       env:

--- a/.github/workflows/sync_community_teams.yml
+++ b/.github/workflows/sync_community_teams.yml
@@ -9,17 +9,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Install system dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pipenv
+    - uses: actions/checkout@v3
+    - name: Install app dependencies
+      run: |
         pipenv sync
-    - name: Export token to env and run script
+    - name: Run script with tokens in env
       run: |
         pipenv run ./sync_community_teams.py
       env:


### PR DESCRIPTION
## Description
My previous PRs (#151, #152) broke the order of operations (a checkout is required before there is a `Pipfile` to use)

This PR clearly delineates system and app python configurations and fixes the order of operations.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
