### PR TITLE
Logging sync etc

### DIFF
--- a/ccos/data/get_repo_data.py
+++ b/ccos/data/get_repo_data.py
@@ -13,36 +13,36 @@ from github import Github
 from github.GithubException import GithubException, UnknownObjectException
 
 # First-party/Local
-from ccos import log
+import ccos.log
 from ccos.data.push_data_via_git import GITHUB_ORGANIZATION, GITHUB_TOKEN
 
 CC_METADATA_FILE_NAME = ".cc-metadata.yml"
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
-logger = logging.getLogger(log_name)
-log.reset_handler()
+LOG = logging.getLogger(log_name)
+ccos.log.reset_handler()
 
 
 def set_up_github_client():
-    logger.log(logging.INFO, "Setting up GitHub client...")
+    LOG.info("Setting up GitHub client...")
     github_client = Github(GITHUB_TOKEN)
     return github_client
 
 
 def get_cc_organization(github_client):
-    logger.log(logging.INFO, "Getting CC's GitHub organization...")
+    LOG.info("Getting CC's GitHub organization...")
     cc = github_client.get_organization(GITHUB_ORGANIZATION)
     return cc
 
 
 def get_repositories(organization):
-    logger.log(logging.INFO, "Getting CC's repos...")
+    LOG.info("Getting CC's repos...")
     repos = organization.get_repos()
     return repos
 
 
 def get_repo_github_data(repo):
-    logger.log(logging.INFO, "Getting data for this repo...")
+    LOG.info("Getting data for this repo...")
     repo_github_data = {
         "id": repo.id,
         "name": repo.name,
@@ -69,7 +69,7 @@ def get_repo_github_data(repo):
 
 
 def get_repo_cc_metadata(repo):
-    logger.log(logging.INFO, "Getting CC metadata for this repo...")
+    LOG.info("Getting CC metadata for this repo...")
     try:
         cc_metadata_file = repo.get_contents(CC_METADATA_FILE_NAME)
     except (UnknownObjectException, GithubException):
@@ -89,9 +89,7 @@ def get_repo_data_list(repos):
     total = repos.totalCount
 
     for repo in repos:
-        logger.log(
-            logging.INFO, f"Processing {count} of {total} – {repo.name}"
-        )
+        LOG.info(f"Processing {count} of {total} – {repo.name}")
         if not repo.private:
             repo_cc_metadata = get_repo_cc_metadata(repo)
             is_engineering_project = repo_cc_metadata.get(
@@ -104,9 +102,7 @@ def get_repo_data_list(repos):
                 repo_data = {**repo_github_data, **repo_cc_metadata}
                 repo_data_list.append(repo_data)
             else:
-                logger.log(
-                    logging.INFO, "Not an active engineering project, skipping"
-                )
+                LOG.info("Not an active engineering project, skipping")
         count += 1
     return sorted(repo_data_list, key=lambda k: k["name"].lower())
 

--- a/ccos/data/push_data_via_git.py
+++ b/ccos/data/push_data_via_git.py
@@ -6,13 +6,13 @@ import inspect
 import json
 import logging
 import os
-import tempfile
+from tempfile import TemporaryDirectory
 
 # Third-party
 import git
 
 # First-party/Local
-from ccos import log
+import ccos.log
 
 GIT_USER_NAME = "CC creativecommons.github.io Bot"
 GIT_USER_EMAIL = "cc-creativecommons-github-io-bot@creativecommons.org"
@@ -30,26 +30,26 @@ GITHUB_REPO_URL_WITH_CREDENTIALS = (
 JSON_FILE_DIR = "databags"
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
-logger = logging.getLogger(log_name)
-log.reset_handler()
+LOG = logging.getLogger(log_name)
+ccos.log.reset_handler()
 
 
 def set_up_repo(git_working_dir):
     if not os.path.isdir(git_working_dir):
-        logger.log(logging.INFO, "Cloning repo...")
+        LOG.info("Cloning repo...")
         repo = git.Repo.clone_from(
             url=GITHUB_REPO_URL_WITH_CREDENTIALS, to_path=git_working_dir
         )
     else:
-        logger.log(logging.INFO, "Setting up repo...")
+        LOG.info("Setting up repo...")
         repo = git.Repo(git_working_dir)
     origin = repo.remotes.origin
-    logger.log(logging.INFO, "Pulling latest code...")
+    LOG.info("Pulling latest code...")
     origin.pull()
 
 
 def set_up_git_user():
-    logger.log(logging.INFO, "Setting up git user...")
+    LOG.info("Setting up git user...")
     os.environ["GIT_AUTHOR_NAME"] = GIT_USER_NAME
     os.environ["GIT_AUTHOR_EMAIL"] = GIT_USER_EMAIL
     os.environ["GIT_COMMITTER_NAME"] = GIT_USER_NAME
@@ -57,7 +57,7 @@ def set_up_git_user():
 
 
 def generate_json_file(git_working_dir, data, filename):
-    logger.log(logging.INFO, "Generating JSON file...")
+    LOG.info("Generating JSON file...")
     json_filename = os.path.join(git_working_dir, JSON_FILE_DIR, filename)
     with open(json_filename, "w") as json_file:
         json.dump(data, json_file, sort_keys=True, indent=4)
@@ -71,14 +71,14 @@ def commit_and_push_changes(git_working_dir, json_filename):
         repo.index.add(items=f"{json_filename}")
         repo.index.commit(message="Syncing new data changes.")
         origin = repo.remotes.origin
-        logger.log(logging.INFO, "Pushing latest code...")
+        LOG.info("Pushing latest code...")
         origin.push()
     else:
-        logger.log(logging.INFO, "No changes to push...")
+        LOG.info("No changes to push...")
 
 
 def push_data(data, filename):
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with TemporaryDirectory() as temp_dir:
         git_working_dir = os.path.join(temp_dir, GITHUB_REPO_NAME)
         set_up_repo(git_working_dir)
         set_up_git_user()

--- a/ccos/gh_utils.py
+++ b/ccos/gh_utils.py
@@ -10,21 +10,21 @@ from github import Github
 from github.GithubException import BadCredentialsException
 
 # First-party/Local
-from ccos import log
+import ccos.log
 
 GITHUB_ORGANIZATION = "creativecommons"
 GITHUB_USERNAME_DEFAULT = "cc-creativecommons-github-io-bot"
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
-logger = logging.getLogger(log_name)
-log.reset_handler()
+LOG = logging.getLogger(log_name)
+ccos.log.reset_handler()
 
 
 def get_credentials():
     try:
         github_token = os.environ["ADMIN_GITHUB_TOKEN"]
     except KeyError:
-        logger.critical("missing ADMIN_GITHUB_TOKEN environment variable")
+        LOG.critical("missing ADMIN_GITHUB_TOKEN environment variable")
         sys.exit(1)
     try:
         github_username = os.environ["ADMIN_GITHUB_USERNAME"]
@@ -35,23 +35,23 @@ def get_credentials():
 
 def set_up_github_client():
     _, github_token = get_credentials()
-    logger.log(logging.INFO, "Setting up GitHub client...")
+    LOG.info("Setting up GitHub client...")
     github_client = Github(github_token)
-    logger.log(log.SUCCESS, "done.")
+    LOG.log(ccos.log.SUCCESS, "done.")
     return github_client
 
 
 def get_cc_organization(github_client):
-    logger.log(logging.INFO, "Getting CC's GitHub organization...")
+    LOG.info("Getting CC's GitHub organization...")
     try:
         cc = github_client.get_organization(GITHUB_ORGANIZATION)
     except BadCredentialsException as e:
-        logger.critical(
+        LOG.critical(
             f"{e.status} {e.data['message']} (see"
             f" {e.data['documentation_url']})"
         )
         sys.exit(1)
-    logger.log(log.SUCCESS, "done.")
+    LOG.log(ccos.log.SUCCESS, "done.")
     return cc
 
 

--- a/ccos/gh_utils.py
+++ b/ccos/gh_utils.py
@@ -13,23 +13,30 @@ from github.GithubException import BadCredentialsException
 from ccos import log
 
 GITHUB_ORGANIZATION = "creativecommons"
-GITHUB_USERNAME = "cc-creativecommons-github-io-bot"
-GITHUB_TOKEN = None
+GITHUB_USERNAME_DEFAULT = "cc-creativecommons-github-io-bot"
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
 logger = logging.getLogger(log_name)
 log.reset_handler()
 
 
-def set_up_github_client():
-    global GITHUB_TOKEN
+def get_credentials():
     try:
-        GITHUB_TOKEN = os.environ["ADMIN_GITHUB_TOKEN"]
+        github_token = os.environ["ADMIN_GITHUB_TOKEN"]
     except KeyError:
         logger.critical("missing ADMIN_GITHUB_TOKEN environment variable")
         sys.exit(1)
+    try:
+        github_username = os.environ["ADMIN_GITHUB_USERNAME"]
+    except KeyError:
+        github_username = GITHUB_USERNAME_DEFAULT
+    return github_username, github_token
+
+
+def set_up_github_client():
+    _, github_token = get_credentials()
     logger.log(logging.INFO, "Setting up GitHub client...")
-    github_client = Github(GITHUB_TOKEN)
+    github_client = Github(github_token)
     logger.log(log.SUCCESS, "done.")
     return github_client
 

--- a/ccos/log.py
+++ b/ccos/log.py
@@ -70,7 +70,7 @@ class IndentFormatter(logging.Formatter):
                 "%(message)s"
             )
         else:
-            self._style._fmt += f"%(indent)s%(message)s"
+            self._style._fmt += "%(indent)s%(message)s"
 
     def format(self, record):
         """

--- a/ccos/log.py
+++ b/ccos/log.py
@@ -72,7 +72,6 @@ class IndentFormatter(logging.Formatter):
         else:
             self._style._fmt += f"%(indent)s%(message)s"
 
-
     def format(self, record):
         """
         Format the log message with additional data extracted from the stack.

--- a/ccos/log.py
+++ b/ccos/log.py
@@ -18,6 +18,7 @@ class IndentFormatter(logging.Formatter):
         logging.WARNING: 33,  # yellow
         SUCCESS: 32,  # green
         logging.INFO: 34,  # blue
+        logging.DEBUG: 35,  # magenta
     }
 
     @staticmethod

--- a/ccos/norm/set_labels.py
+++ b/ccos/norm/set_labels.py
@@ -4,11 +4,11 @@ import logging
 import os.path
 
 # First-party/Local
-from ccos import log
+import ccos.log
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
-logger = logging.getLogger(log_name)
-log.reset_handler()
+LOG = logging.getLogger(log_name)
+ccos.log.reset_handler()
 
 
 def map_repo_to_labels(repo, final_labels, non_destructive=True):
@@ -21,53 +21,53 @@ def map_repo_to_labels(repo, final_labels, non_destructive=True):
     @param non_destructive: whether to trim extra labels or preserve them
     """
 
-    logger.log(logging.INFO, "Fetching initial labels...")
+    LOG.info("Fetching initial labels...")
     initial_labels = {
         label.name.casefold(): label for label in repo.get_labels()
     }
-    logger.log(log.SUCCESS, f"done. Found {len(initial_labels)} labels.")
+    LOG.log(ccos.log.SUCCESS, f"done. Found {len(initial_labels)} labels.")
 
-    logger.log(logging.INFO, "Parsing final labels...")
+    LOG.info("Parsing final labels...")
     final_labels = {
         label.qualified_name.casefold(): label for label in final_labels
     }
-    logger.log(log.SUCCESS, f"done. Found {len(final_labels)} labels.")
+    LOG.log(ccos.log.SUCCESS, f"done. Found {len(final_labels)} labels.")
 
     if not non_destructive:
-        logger.log(logging.INFO, "Syncing initial labels...")
-        log.change_indent(+1)
+        LOG.info("Syncing initial labels...")
+        ccos.log.change_indent(+1)
         for initial_label_name, initial_label in initial_labels.items():
-            logger.log(logging.INFO, f"Syncing '{initial_label_name}'...")
-            log.change_indent(+1)
+            LOG.info(f"Syncing '{initial_label_name}'...")
+            ccos.log.change_indent(+1)
             if initial_label_name not in final_labels:
-                logger.log(logging.INFO, "Does not exist, deleting...")
+                LOG.info("Does not exist, deleting...")
                 initial_label.delete()
-                logger.log(log.SUCCESS, "done.")
-            log.change_indent(-1)
-            logger.log(log.SUCCESS, "done.")
-        log.change_indent(-1)
-        logger.log(log.SUCCESS, "done.")
+                LOG.log(ccos.log.SUCCESS, "done.")
+            ccos.log.change_indent(-1)
+            LOG.log(ccos.log.SUCCESS, "done.")
+        ccos.log.change_indent(-1)
+        LOG.log(ccos.log.SUCCESS, "done.")
 
-    logger.log(logging.INFO, "Syncing final labels...")
-    log.change_indent(+1)
+    LOG.info("Syncing final labels...")
+    ccos.log.change_indent(+1)
     for final_label_name, final_label in final_labels.items():
-        logger.log(logging.INFO, f"Syncing '{final_label_name}'...")
-        log.change_indent(+1)
+        LOG.info(f"Syncing '{final_label_name}'...")
+        ccos.log.change_indent(+1)
         if final_label_name not in initial_labels:
-            logger.log(logging.INFO, "Did not exist, creating...")
+            LOG.info("Did not exist, creating...")
             repo.create_label(**final_label.api_arguments)
-            logger.log(log.SUCCESS, "done.")
+            LOG.log(ccos.log.SUCCESS, "done.")
         elif final_label != initial_labels[final_label_name]:
-            logger.log(logging.INFO, "Differences found, updating...")
+            LOG.info("Differences found, updating...")
             initial_label = initial_labels[final_label_name]
             initial_label.edit(**final_label.api_arguments)
-            logger.log(log.SUCCESS, "done.")
+            LOG.log(ccos.log.SUCCESS, "done.")
         else:
-            logger.log(logging.INFO, "Match found, moving on.")
-        log.change_indent(-1)
-        logger.log(log.SUCCESS, "done.")
-    log.change_indent(-1)
-    logger.log(log.SUCCESS, "done.")
+            LOG.info("Match found, moving on.")
+        ccos.log.change_indent(-1)
+        LOG.log(ccos.log.SUCCESS, "done.")
+    ccos.log.change_indent(-1)
+    LOG.log(ccos.log.SUCCESS, "done.")
 
 
 def set_labels(repos, standard_labels, repo_specific_labels):
@@ -77,12 +77,12 @@ def set_labels(repos, standard_labels, repo_specific_labels):
     """
 
     for repo in list(repos):
-        logger.log(logging.INFO, f"Getting labels for repo '{repo.name}'...")
+        LOG.info(f"Getting labels for repo '{repo.name}'...")
         labels = standard_labels + repo_specific_labels.get(repo.name, [])
-        logger.log(log.SUCCESS, f"done. Found {len(labels)} labels.")
-        logger.log(logging.INFO, f"Syncing labels for repo '{repo.name}'...")
+        LOG.log(ccos.log.SUCCESS, f"done. Found {len(labels)} labels.")
+        LOG.info(f"Syncing labels for repo '{repo.name}'...")
         map_repo_to_labels(repo, labels)
-        logger.log(log.SUCCESS, "done.")
+        LOG.log(ccos.log.SUCCESS, "done.")
 
 
 __all__ = ["set_labels"]

--- a/ccos/teams/get_community_team_data.py
+++ b/ccos/teams/get_community_team_data.py
@@ -17,7 +17,7 @@ import re
 import requests
 
 # First-party/Local
-from ccos import log
+import ccos.log
 
 # Constants should match 'push_data_to_ccos/push_data_via_git.py'
 GITHUB_ORGANIZATION = "creativecommons"
@@ -32,8 +32,8 @@ DATABAG_URL = (
 )
 
 log_name = os.path.basename(os.path.splitext(inspect.stack()[-1].filename)[0])
-logger = logging.getLogger(log_name)
-log.reset_handler()
+LOG = logging.getLogger(log_name)
+ccos.log.reset_handler()
 
 
 def fetch_databag():
@@ -63,15 +63,15 @@ def fetch_databag():
         ]
     }
     """
-    logging.log(logging.INFO, "Pulling from OS@CC...")
+    LOG.info("Pulling from OS@CC...")
     databag = {"projects": []}
 
     request = requests.get(DATABAG_URL)
     request.raise_for_status()
     projects = request.json()["projects"]
-    logging.log(logging.INFO, "Team members pulled.")
+    LOG.info("Team members pulled.")
 
-    logging.log(logging.INFO, "Processing team members...")
+    LOG.info("Processing team members...")
     for project in projects:
         formatted_project = {
             "name": project["name"],
@@ -87,8 +87,8 @@ def fetch_databag():
             formatted_project["roles"][role].append(member)
         databag["projects"].append(formatted_project)
 
-    logging.log(log.SUCCESS, "Done.")
-    logging.log(log.SUCCESS, "Pull successful.")
+    LOG.log(ccos.log.SUCCESS, "Done.")
+    LOG.log(ccos.log.SUCCESS, "Pull successful.")
     return databag
 
 

--- a/ccos/teams/set_codeowners.py
+++ b/ccos/teams/set_codeowners.py
@@ -54,7 +54,7 @@ def create_codeowners_for_data(databag):
         teams = get_teams(organization, project_name, roles)
         logging.log(
             logging.INFO,
-            f"        Found {len(teams)} teams for project {project_name}.",
+            f"Found {len(teams)} teams for project {project_name}.",
         )
 
         logging.log(logging.INFO, "Checking all projects...")

--- a/ccos/teams/set_codeowners.py
+++ b/ccos/teams/set_codeowners.py
@@ -4,8 +4,8 @@ import inspect
 import logging
 import os
 import os.path
-import shutil
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 # Third-party
 import git
@@ -14,17 +14,14 @@ import git
 from ccos import log
 from ccos.gh_utils import (
     GITHUB_ORGANIZATION,
-    GITHUB_TOKEN,
-    GITHUB_USERNAME,
     get_cc_organization,
+    get_credentials,
     set_up_github_client,
 )
 from ccos.teams.set_teams_on_github import map_role_to_team
 
 GIT_USER_NAME = "CC creativecommons.github.io Bot"
 GIT_USER_EMAIL = "cc-creativecommons-github-io-bot@creativecommons.org"
-
-WORKING_DIRECTORY = Path("/tmp").resolve()
 
 SYNC_BRANCH = "ct_codeowners"
 
@@ -35,9 +32,8 @@ log.reset_handler()
 
 def create_codeowners_for_data(databag):
     set_up_git_user()
-
-    client = set_up_github_client()
-    organization = get_cc_organization(client)
+    github_client = set_up_github_client()
+    organization = get_cc_organization(github_client)
 
     logging.log(logging.INFO, "Identifying and fixing CODEOWNER issues...")
     projects = databag["projects"]
@@ -59,8 +55,9 @@ def create_codeowners_for_data(databag):
 
         logging.log(logging.INFO, "Checking all projects...")
         repos = project["repos"]
-        for repo in repos:
-            check_and_fix_repo(organization, repo, teams)
+        with TemporaryDirectory() as temp_dir:
+            for repo_name in repos:
+                check_and_fix_repo(organization, repo_name, teams, temp_dir)
     logging.log(log.SUCCESS, "Done")
 
 
@@ -95,7 +92,7 @@ def get_teams(organization, project_name, roles):
     return [team for team in role_team_map.values() if team is not None]
 
 
-def check_and_fix_repo(organization, repo, teams):
+def check_and_fix_repo(organization, repo_name, teams, temp_dir):
     """
     Identify issues with the CODEOWNERS file and rectify them. Missing
     CODEOWNERS files will be created. Incomplete CODEOWNERS files will be
@@ -105,42 +102,43 @@ def check_and_fix_repo(organization, repo, teams):
     @param repo: the repo to which the CODEOWNERS file being modified belongs
     """
 
-    logging.log(logging.INFO, f"Checking and fixing {repo}...")
-    set_up_repo(repo)
+    logging.log(logging.INFO, f"Checking and fixing {repo_name}...")
+    repo_dir = os.path.join(temp_dir, repo_name)
+    gh_repo = organization.get_repo(repo_name)
+    clone_url = get_github_repo_url_with_credentials(repo_name)
+    local_repo = set_up_repo(clone_url, repo_dir)
+    codeowners_path = Path(os.path.join(repo_dir, ".github", "CODEOWNERS"))
     fix_required = False
 
-    if not is_codeowners_present(repo):
+    if not codeowners_path.exists() and codeowners_path.is_file():
         fix_required = True
-        codeowners_path = get_codeowners_path(repo)
-        logging.log(logging.INFO, " CODEOWNERS does not exist, creating...")
+        logging.log(logging.INFO, "CODEOWNERS does not exist, creating...")
         os.makedirs(codeowners_path.parent, exist_ok=True)
         open(codeowners_path, "a").close()
-        logging.log(log.SUCCESS, "                Done.")
+        logging.log(log.SUCCESS, "Done.")
 
-    team_mention_map = get_team_mention_map(repo, teams)
+    team_mention_map = get_team_mention_map(codeowners_path, teams)
     if not all(team_mention_map.values()):
         fix_required = True
         logging.log(logging.INFO, "CODEOWNERS is incomplete, populating...")
-        add_missing_teams(repo, team_mention_map)
-        logging.log(log.SUCCESS, "                Done.")
+        add_missing_teams(codeowners_path, team_mention_map)
+        logging.log(log.SUCCESS, "Done.")
 
     if fix_required:
         logging.log(logging.INFO, "Pushing to GitHub...")
-        branch_name = commit_and_push_changes(repo)
+        branch_name = commit_and_push_changes(local_repo, codeowners_path)
         logging.log(log.SUCCESS, f"Pushed to {branch_name}.")
 
         logging.log(logging.INFO, "Opening a PR...")
-        pr = create_pull_request(organization, repo, branch_name)
-        logging.log(log.SUCCESS, f"                PR at {pr.url}.")
+        pr = create_pull_request(gh_repo, branch_name)
+        logging.log(log.SUCCESS, f"PR at {pr.url}.")
 
-    logging.log(logging.INFO, "Deleting clone...")
-    shutil.rmtree(get_repo_path(repo))
     logging.log(log.SUCCESS, "Done.")
 
     logging.log(log.SUCCESS, "All is well.")
 
 
-def commit_and_push_changes(repo):
+def commit_and_push_changes(local_repo, codeowners_path):
     """
     Create a new branch and push the CODEOWNER to it. This branch will be named
     in a particular format.
@@ -148,36 +146,34 @@ def commit_and_push_changes(repo):
     codeowner branch schema
     ct_codeowners_<timestamp>
 
-    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param local_repo: GitPython Repo instance for the repo to which the
+                       CODEOWNERS file being modified belongs
+    @param codeowners_path: the path of the CODEOWNERS file
     @return: the name of the branch to which the changes were pushed
     """
-    repo = git.Repo(get_repo_path(repo))
-
     timestamp = int(datetime.datetime.now().timestamp())
     branch_name = f"{SYNC_BRANCH}_{timestamp}"
-    repo.git.checkout("HEAD", b=branch_name)
+    local_repo.git.checkout("HEAD", b=branch_name)
 
-    repo.index.add(items=".github/CODEOWNERS")
-    repo.index.commit(message="Sync Community Team to CODEOWNERS")
+    local_repo.index.add(items=codeowners_path)
+    local_repo.index.commit(message="Sync Community Team(s) to CODEOWNERS")
 
-    origin = repo.remotes.origin
+    origin = local_repo.remotes.origin
     origin.push(f"{branch_name}:{branch_name}")
 
     return branch_name
 
 
-def create_pull_request(organization, repo, branch_name):
+def create_pull_request(gh_repo, branch_name):
     """
     Create a PR from the newly created branch to the base branch of the
     repository containing the required changes to the CODEOWNERS.
 
-    @param organization: the organization to which the repository belongs
-    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param gh_repo: PyGithub Repository object
     @param branch_name: the name of the branch containing the CODEOWNERS
                         changes
     """
-    repo = organization.get_repo(repo)
-    return repo.create_pull(
+    return gh_repo.create_pull(
         title="Sync Community Team to CODEOWNERS",
         body=(
             "This _automated PR_ updates your CODEOWNERS file to mention all "
@@ -185,62 +181,42 @@ def create_pull_request(organization, repo, branch_name):
         ),
         head=branch_name,
         # default branch could be 'main', 'master', 'prod', or something else
-        base=repo.default_branch,
+        base=gh_repo.default_branch,
     )
 
 
-def set_up_repo(repo):
+def set_up_repo(clone_url, repo_dir):
     """
     Clone the repository and pull the main branch.
 
-    @param repo: the repository to set up
+    @param clone_url: the authenticated URL to the GitHub repo
+    @param repo_dir: the local directory for the repository
+    @return: GitPython Repo instance
     """
-    destination_path = get_repo_path(repo)
-    if not os.path.isdir(destination_path):
-        logging.log(logging.INFO, "Cloning repo...")
-        repo = git.Repo.clone_from(
-            url=get_github_repo_url_with_credentials(repo),
-            to_path=destination_path,
-        )
-    else:
-        logging.log(logging.INFO, "Setting up repo...")
-        repo = git.Repo(destination_path)
-    origin = repo.remotes.origin
-    logging.log(logging.INFO, "Pulling latest code...")
-    origin.pull()
+    logging.log(logging.INFO, "Cloning repo...")
+    local_repo = git.Repo.clone_from(url=clone_url, to_path=repo_dir)
+    return local_repo
 
 
-def is_codeowners_present(repo):
-    """
-    Check whether the repository has a CODEOWNERS file.
-
-    @param repo: the repository in which to check the existence of CODEOWNERS
-    @return: True if a CODEOWNERS file exists, False otherwise
-    """
-    codeowners_path = get_codeowners_path(repo)
-    return codeowners_path.exists() and codeowners_path.is_file()
-
-
-def get_team_mention_map(repo, teams):
+def get_team_mention_map(codeowners_path, teams):
     """
     Map the team slugs to whether they have been mentioned in the CODEOWNERS
     file in any capacity.
 
-    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param codeowners_path: the path of the CODEOWNERS file
     @param teams: all the GitHub teams for all Community Teams of a project
     @return: a dictionary of team slugs and their mentions
     """
-    codeowners_path = get_codeowners_path(repo)
     with open(codeowners_path) as codeowners_file:
         contents = codeowners_file.read()
     return {team.slug: mentionified(team.slug) in contents for team in teams}
 
 
-def add_missing_teams(repo, team_mention_map):
+def add_missing_teams(codeowners_path, team_mention_map):
     """
     Add the mention forms for all missing teams in a new line.
 
-    @param repo: the repo to which the CODEOWNERS file being modified belongs
+    @param codeowners_path: the path of the CODEOWNERS file
     @param team_mention_map: the dictionary of team slugs and their mentions
     """
     missing_team_slugs = [
@@ -248,7 +224,6 @@ def add_missing_teams(repo, team_mention_map):
         for team_slug in team_mention_map.keys()
         if not team_mention_map[team_slug]
     ]
-    codeowners_path = get_codeowners_path(repo)
     with open(codeowners_path, "a") as codeowners_file:
         addendum = generate_ideal_codeowners_rule(missing_team_slugs)
         codeowners_file.write(addendum)
@@ -267,42 +242,19 @@ def generate_ideal_codeowners_rule(team_slugs):
     return f"* {combined_team_slugs}"
 
 
-def get_github_repo_url_with_credentials(repo):
+def get_github_repo_url_with_credentials(repo_name):
     """
     Get the HTTPS URL to the repository which has the username and a GitHub
     token for authentication.
 
-    @param repo: the name of the repository
-    @return: the authenticated URL to the repo
+    @param repo_name: the name of the repository
+    @return: the authenticated URL to the GitHub repo
     """
+    github_username, github_token = get_credentials()
     return (
-        f"https://{GITHUB_USERNAME}:{GITHUB_TOKEN}"
-        f"@github.com/{GITHUB_ORGANIZATION}/{repo}.git"
+        f"https://{github_username}:{github_token}"
+        f"@github.com/{GITHUB_ORGANIZATION}/{repo_name}.git"
     )
-
-
-def get_repo_path(repo):
-    """
-    Get the fully qualified absolute path to the repository on the local file
-    system. Repositories are cloned into eponymous directories inside the
-    working directory.
-
-    @param repo: the name of the repository
-    @return: the absolute path to cloned repository on local FS
-    """
-    return WORKING_DIRECTORY.joinpath(repo)
-
-
-def get_codeowners_path(repo):
-    """
-    Get the fully qualified absolute path to the CODEOWNERS file inside the
-    given repository. By convention the file should be located inside the
-    '.github/' directory in the repository.
-
-    @param repo: the name of the repository
-    @return: the absolute path to the CODEOWNERS file
-    """
-    return get_repo_path(repo).joinpath(".github", "CODEOWNERS")
 
 
 def mentionified(team_slug):

--- a/push_data_to_ccos.py
+++ b/push_data_to_ccos.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 
 # First-party/Local
-from ccos import log
+import ccos.log
 from ccos.data.get_community_team_data import (
     get_community_team_data,
     setup_asana_client,
@@ -19,9 +19,9 @@ from ccos.data.push_data_via_git import push_data
 
 DAILY_DATABAGS = ["repos", "community_team_members"]
 
-log.set_up_logging()
-logger = logging.getLogger(os.path.basename(__file__))
-log.reset_handler()
+ccos.log.set_up_logging()
+LOG = logging.getLogger(os.path.basename(__file__))
+ccos.log.reset_handler()
 
 
 class ScriptError(Exception):
@@ -53,10 +53,10 @@ def main():
     args = setup()
     asana_client = setup_asana_client()
     if "repos" in args.databags:
-        logger.log(logging.INFO, "updating repos.json")
+        LOG.info("updating repos.json")
         push_data(get_repo_data(), "repos.json")
     if "community_team_members" in args.databags:
-        logger.log(logging.INFO, "community_team_members.json")
+        LOG.info("community_team_members.json")
         repo_names = get_repo_names()
         community_data = get_community_team_data(asana_client, repo_names)
         push_data(community_data, "community_team_members.json")
@@ -68,14 +68,12 @@ if __name__ == "__main__":
     except SystemExit as e:
         sys.exit(e.code)
     except KeyboardInterrupt:
-        logger.log(logging.INFO, "Halted via KeyboardInterrupt.")
+        LOG.info("Halted via KeyboardInterrupt.")
         sys.exit(130)
     except ScriptError:
         error_type, error_value, error_traceback = sys.exc_info()
-        logger.log(logging.CRITICAL, f"{error_value}")
+        LOG.critical(f"{error_value}")
         sys.exit(error_value.code)
     except Exception:
-        logger.log(
-            logging.ERROR, f"Unhandled exception: {traceback.format_exc()}"
-        )
+        LOG.error(f"Unhandled exception: {traceback.format_exc()}")
         sys.exit(1)


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #164, fixes #165, fixes #166, fixes #167, fixes #168, fixes #169
- #164 
- #165 
- #166 
- #167 
- #168 
- #169 

## Description
- All/most files
  - Improve logging ease of use and reliability
- `sync_community_teams.py` and related modules
  - use `tempfile.TemporaryDirectory()` for more reliable behavior
  - consistently use custom logger with global variable name `LOG`
  - add debug argument
  - filter teams so only those with write permissions are added to `CODEOWNERS`
  - properly use credentials using new `ccos.gh_utils.get_credentials()` function
  - reduce code duplication
    - set variables once and pass them
    - improve (re)use of PyGithub objects
  - sort lists for predictable output / prevent churn
  - remove extra whitespace from log messages
  - ensure all global matches (`*`) are written to one line

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
All scripts tested successfully on my laptop

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
