### PR TITLE
update `track_issues_and_pull_requests.py` search query as `no:project` does not work as expected

### DIFF
--- a/track_issues_and_pull_requests.py
+++ b/track_issues_and_pull_requests.py
@@ -47,7 +47,10 @@ def setup():
 def get_untracked_issues(github_client):
     LOG.info("Searching for untracked open issues")
     # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
-    query = "org:creativecommons state:open no:project type:issue"
+    query = (
+        "org:creativecommons state:open -project:creativecommons/7"
+        " -project:creativecommons/10 type:issue"
+    )
     LOG.debug(f"issues query: {query}")
     untracked_issues = list(github_client.search_issues(query=query))
     untracked_issues.sort(key=lambda x: f"{x.repository.name}{x.number:09}")
@@ -90,7 +93,10 @@ def track_issues(args, gh_org_cc, untracked_issues):
 def get_untracked_pull_requests(github_client):
     LOG.info("Searching for untracked open pull requests")
     # https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
-    query = "org:creativecommons state:open no:project type:pr"
+    query = (
+        "org:creativecommons state:open -project:creativecommons/7"
+        " -project:creativecommons/10 type:pr"
+    )
     LOG.debug(f"pull request query: {query}")
     untracked_pull_requests = list(github_client.search_issues(query=query))
     untracked_pull_requests.sort(


### PR DESCRIPTION
## Description
update `track_issues_and_pull_requests.py` search query as `no:project` does not work as expected

## Technical details
- https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-missing-metadata excerpt:
  > Qualifier | Example
  > -- | --
  > `no:project` | [build no:project](https://github.com/search?utf8=%E2%9C%93&q=build+no%3Aproject&type=Issues) matches issues not associated with a project board, containing the word "build."
- https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#exclude-results-that-match-a-qualifier excerpt:
  > You can narrow down search results by excluding one or more subsets. To exclude all results that are matched by a qualifier, prefix the search qualifier with a hyphen (`-`).
- https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-project-board excerpt:
  > Qualifier | Example
  > -- | --
  > <code>project:<em>PROJECT_BOARD</em></code> | project:github/57 matches issues owned by GitHub that are associated with the organization's project board 57.

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
