### PR TITLE
Enable workflows: Ensure no leading/trailing whitespace is included in specified repo(s)

### DIFF
--- a/dev/tools.sh
+++ b/dev/tools.sh
@@ -1,16 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Run Python code tools (isort, black, flake8)
+#
 #### SETUP ####################################################################
+
+set -o errexit
 set -o errtrace
 set -o nounset
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'isort'
+# shellcheck disable=SC2154
+trap '_es=${?};
+    printf "${0}: line ${LINENO}: \"${BASH_COMMAND}\"";
+    printf " exited with a status of ${_es}\n";
+    exit ${_es}' ERR
+
+DIR_REPO="$(cd -P -- "${0%/*}/.." && pwd -P)"
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+E0="$(printf "\e[0m")"        # reset
+E30="$(printf "\e[30m")"      # black foreground
+E31="$(printf "\e[31m")"      # red foreground
+E107="$(printf "\e[107m")"    # bright white background
+
+#### FUNCTIONS ################################################################
+
+error_exit() {
+    # Echo error message and exit with error
+    echo -e "${E31}ERROR:${E0} ${*}" 1>&2
+    exit 1
+}
+
+print_header() {
+    # Print 80 character wide black on white heading with time
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+#### MAIN #####################################################################
+
+cd "${DIR_REPO}"
+
+print_header 'isort'
+# shellcheck disable=SC2068
 pipenv run isort ${@:-.}
 echo
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'black'
+print_header 'black'
+# shellcheck disable=SC2068
 pipenv run black ${@:-.}
 echo
 
-printf "\e[1m\e[7m %-80s\e[0m\n" 'flake8'
+print_header 'flake8'
+# shellcheck disable=SC2068
 pipenv run flake8 ${@:-.}
 echo

--- a/enable_workflows.py
+++ b/enable_workflows.py
@@ -50,6 +50,8 @@ def setup():
         args.dryrun = ""
     if not args.repos:
         raise ap.error("at least one (1) REPOSITORY must be specified")
+    for i, repo in enumerate(args.repos):
+        args.repos[i] = repo.strip()
     return args
 
 


### PR DESCRIPTION
## Description
- Enable workflows: Ensure no leading/trailing whitespace is included in specified repo(s)

## Technical details
Fixes error during GitHub Actions run:
```
2025-04-23 14:44:40,734 │ INFO     │ setup_github_rest_client: Setting up GitHub Rest API client
2025-04-23 14:44:40,734 │ INFO     │ get_cc_organization: Getting CC's GitHub organization...
2025-04-23 14:44:40,894 │ SUCCESS  │ get_cc_organization: done.
2025-04-23 14:44:40,894 │ INFO     │ get_select_repos: Get select GitHub repositories
2025-04-23 14:44:42,799 │ ERROR    │ <module>: Unhandled exception: Traceback (most recent call last):
  File "/home/runner/work/ccos-scripts/ccos-scripts/./enable_workflows.py", line 86, in <module>
    main()
  File "/home/runner/work/ccos-scripts/ccos-scripts/./enable_workflows.py", line 79, in main
    repos = gh_utils.get_select_repos(args, gh_org_cc)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ccos-scripts/ccos-scripts/ccos/gh_utils.py", line 144, in get_select_repos
    raise Exception(
Exception: Specified repositories do not include any valid repositories: [' ccos_scripts']

Error: Process completed with exit code 1.
```

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
